### PR TITLE
fixed highlighting issues + mutli file display from gists

### DIFF
--- a/app/blog/posts/static-typing.mdx
+++ b/app/blog/posts/static-typing.mdx
@@ -19,7 +19,7 @@ function greet(name: string): string {
 let message: string = greet(123)
 ```
 
-<OpenGistCode url="https://gist.gopalji.me/gopalji/be5b67d60529485881a7d32d6dc2acd5.js" />
+<OpenGistCode url="https://gist.gopalji.me/gopalji/be5b67d60529485881a7d32d6dc2acd5#file-test-py" />
 
 ## Enhanced Readability and Maintainability
 

--- a/app/components/code.tsx
+++ b/app/components/code.tsx
@@ -13,19 +13,27 @@ interface OpenGistCodeProps {
   url: string
 }
 
+interface GistFile {
+  filename: string
+  content: string
+  type: string
+}
+
 interface GistData {
-  code: string
-  language: string
+  files: GistFile[]
 }
 
 export function Code({ children, ...props }) {
   const [copied, setCopied] = useState(false)
   const [element, setElement] = useState(null)
 
+  const language =
+    props.language || props.className?.replace('language-', '') || 'javascript'
+
   useEffect(() => {
     const highlight = async () => {
       const hast = await codeToHast(children, {
-        lang: props.language,
+        lang: language,
         theme: 'dark-plus',
       })
 
@@ -42,7 +50,7 @@ export function Code({ children, ...props }) {
     }
 
     highlight()
-  }, [children, props.language])
+  }, [children, language])
 
   const handleCopy = () => {
     navigator.clipboard.writeText(children).then(() => {
@@ -57,7 +65,7 @@ export function Code({ children, ...props }) {
     <div className="relative">
       <button
         onClick={handleCopy}
-        className="absolute top-1 right-0 z-10 cursor-pointer rounded p-1.5 text-neutral-400 transition-colors hover:bg-neutral-800"
+        className="absolute top-0 right-0 z-10 cursor-pointer rounded p-1.5 text-neutral-400 transition-colors hover:bg-neutral-800"
       >
         {copied ? (
           <GoCheck className="stroke-1 text-green-600" />
@@ -70,60 +78,44 @@ export function Code({ children, ...props }) {
   )
 }
 
-const fetchGistCode = async (url: string): Promise<GistData> => {
-  const response = await fetch(url)
+const fetchGistCode = async (url: string) => {
+  // Parse URL to get the hash fragment (e.g., #file-test-py)
+  const urlParts = url.split('#')
+  const baseUrl = urlParts[0]
+  const fileHash = urlParts[1] // e.g., "file-test-py"
+
+  // Fetch the JSON (base URL + .json)
+  const jsonUrl = `${baseUrl}.json`
+
+  const response = await fetch(jsonUrl)
 
   if (!response.ok) {
     throw new Error(`Failed to fetch: ${response.status}`)
   }
 
-  const scriptContent = await response.text()
+  const data: GistData = await response.json()
 
-  const writeMatch = scriptContent.match(/document\.write\("(.+)"\);/s)
-  if (!writeMatch) {
-    throw new Error('No document.write found')
-  }
+  if (fileHash) {
+    // Find specific file by hash
+    const file = data.files.find((f) => {
+      const slug = 'file-' + f.filename.toLowerCase().replace(/\./g, '-')
+      return slug === fileHash.toLowerCase()
+    })
 
-  let htmlContent = writeMatch[1]
+    if (!file) {
+      throw new Error(`File not found: ${fileHash}`)
+    }
 
-  htmlContent = htmlContent.replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) =>
-    String.fromCharCode(parseInt(hex, 16)),
-  )
-
-  htmlContent = htmlContent
-    .replace(/\\'/g, "'")
-    .replace(/\\"/g, '"')
-    .replace(/\\\//g, '/')
-    .replace(/\\n/g, '\n')
-
-  const parser = new DOMParser()
-  const doc = parser.parseFromString(htmlContent, 'text/html')
-
-  const parserError = doc.querySelector('parsererror')
-  if (parserError) {
-    throw new Error('Failed to parse HTML')
-  }
-
-  const table = doc.querySelector('table.chroma')
-  let language = 'text'
-
-  const dataFilename = table?.getAttribute('data-filename')
-  if (dataFilename) {
-    language = dataFilename.split('.').pop()?.toLowerCase() || 'text'
-  }
-
-  const codeCells = doc.querySelectorAll('td.line-code')
-  if (codeCells.length === 0) {
-    throw new Error('No code found')
-  }
-
-  const codeLines = Array.from(codeCells).map((cell) => {
-    return cell.textContent || ''
-  })
-
-  return {
-    code: codeLines.join(''),
-    language,
+    return {
+      files: [file],
+      allFiles: false,
+    }
+  } else {
+    // No hash specified, return all files
+    return {
+      files: data.files,
+      allFiles: true,
+    }
   }
 }
 
@@ -133,7 +125,7 @@ export function OpenGistCode({ url }: OpenGistCodeProps) {
     revalidateOnReconnect: false,
   })
 
-  const gistUrl = url.replace(/\.js$/, '')
+  const gistUrl = url
 
   if (isLoading) {
     return (
@@ -157,19 +149,33 @@ export function OpenGistCode({ url }: OpenGistCodeProps) {
   }
 
   return (
-    <div className="group relative my-4">
-      <a
-        href={gistUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-xm !hover:bg-neutral-800 absolute right-3 bottom-2 z-10 rounded px-1.5 py-1 !text-neutral-400 transition-colors"
-        title="Open Gist"
-      >
-        <GoArrowUpRight className="stroke-1" />
-      </a>
-      <pre>
-        <Code language={data.language}>{data.code}</Code>
-      </pre>
+    <div className="my-4 space-y-4">
+      {data.files.map((file, index) => (
+        <div key={index} className="group relative overflow-hidden rounded-lg">
+          {/* Title bar */}
+          <div className="flex items-center justify-between border-b border-neutral-700 bg-neutral-800/50 px-4 py-2">
+            <span className="text-sm text-neutral-400">{file.filename}</span>
+            <a
+              href={
+                data.allFiles
+                  ? `${gistUrl}#file-${file.filename.toLowerCase().replace(/\./g, '-')}`
+                  : gistUrl
+              }
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-xs !text-neutral-500 transition-colors hover:!text-neutral-400"
+              title="Open Gist"
+            >
+              open gist
+              <GoArrowUpRight className="h-3 w-3" />
+            </a>
+          </div>
+          {/* Code block */}
+          <pre className="!m-0 !rounded-none">
+            <Code language={file.type.toLowerCase()}>{file.content}</Code>
+          </pre>
+        </div>
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
This pull request refactors the `OpenGistCode` component and its supporting code to improve how Gist code snippets are fetched and displayed. The main improvements include fetching Gist data as JSON to support multi-file Gists, displaying each file with its filename and syntax highlighting, and cleaning up code for better maintainability.

**Gist fetching and display improvements:**

* Refactored `fetchGistCode` to fetch Gist data as JSON, supporting multiple files and allowing selection of a specific file via the URL hash fragment. The code now returns an array of files and their types for syntax highlighting.
* Updated `OpenGistCode` to render each file in the Gist with a filename header, syntax highlighting based on file type, and a direct link to the Gist or specific file.
* Changed the Gist embed URL in `app/blog/posts/static-typing.mdx` to use the hash fragment for selecting a specific file, matching the new logic.

**Code and UI enhancements:**

* Improved the `Code` component to better determine the language for syntax highlighting, and fixed the copy button's positioning for consistency. [[1]](diffhunk://#diff-c854c9f285d44826e907fe27fc1d70674947b8bd43cde2058686b46297dcb918R16-R36) [[2]](diffhunk://#diff-c854c9f285d44826e907fe27fc1d70674947b8bd43cde2058686b46297dcb918L45-R53) [[3]](diffhunk://#diff-c854c9f285d44826e907fe27fc1d70674947b8bd43cde2058686b46297dcb918L60-R68)
* Simplified the handling of Gist URLs and removed unnecessary replacements.