### PR TITLE
fix: lazy-init Resend in all routes to prevent build crash when API key missing

### DIFF
--- a/app/api/cron/newsletter/route.ts
+++ b/app/api/cron/newsletter/route.ts
@@ -4,7 +4,6 @@ import { kv } from '@vercel/kv'
 import { createHmac } from 'crypto'
 import { getBlogPosts } from 'app/blog/utils'
 
-const resend = new Resend(process.env.RESEND_API_KEY)
 const KV_KEY = 'nl:last_sent_slug'
 const SITE_URL = 'https://gopalji.me'
 
@@ -12,6 +11,11 @@ export const runtime = 'nodejs'
 export const maxDuration = 60
 
 export async function GET(req: NextRequest) {
+  if (!process.env.RESEND_API_KEY)
+    return NextResponse.json({ error: 'Service unavailable' }, { status: 503 })
+
+  const resend = new Resend(process.env.RESEND_API_KEY)
+
   const auth = req.headers.get('authorization')
   if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -2,7 +2,6 @@ import { Resend } from 'resend'
 import { NextRequest, NextResponse } from 'next/server'
 import { kv } from '@vercel/kv'
 
-const resend = new Resend(process.env.RESEND_API_KEY)
 const RATE_LIMIT = 5 // per IP per hour
 
 async function checkRateLimit(ip: string): Promise<boolean> {
@@ -17,6 +16,11 @@ async function checkRateLimit(ip: string): Promise<boolean> {
 }
 
 export async function POST(req: NextRequest) {
+  if (!process.env.RESEND_API_KEY)
+    return NextResponse.json({ error: 'Service unavailable' }, { status: 503 })
+
+  const resend = new Resend(process.env.RESEND_API_KEY)
+
   const ip =
     req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'anonymous'
   if (!(await checkRateLimit(ip)))

--- a/app/api/newsletter/unsubscribe/route.ts
+++ b/app/api/newsletter/unsubscribe/route.ts
@@ -2,8 +2,6 @@ import { NextRequest, NextResponse } from 'next/server'
 import { Resend } from 'resend'
 import { createHmac } from 'crypto'
 
-const resend = new Resend(process.env.RESEND_API_KEY)
-
 function verifyToken(email: string, token: string): boolean {
   const expected = createHmac('sha256', process.env.CRON_SECRET ?? '')
     .update(email)
@@ -12,6 +10,11 @@ function verifyToken(email: string, token: string): boolean {
 }
 
 export async function GET(req: NextRequest) {
+  if (!process.env.RESEND_API_KEY)
+    return new NextResponse('Service unavailable.', { status: 503 })
+
+  const resend = new Resend(process.env.RESEND_API_KEY)
+
   const { searchParams } = req.nextUrl
   const email = searchParams.get('e')
   const token = searchParams.get('t')

--- a/app/components/search-chat-modal.tsx
+++ b/app/components/search-chat-modal.tsx
@@ -46,7 +46,6 @@ const PAGES: Item[] = [
   { group: 'Pages', title: 'Blog', href: '/blog' },
   { group: 'Pages', title: 'Projects', href: '/projects' },
   { group: 'Pages', title: 'Misc', href: '/misc' },
-  { group: 'Pages', title: 'Colophon', href: '/colophon' },
 ]
 
 const GROUP_STYLE: Record<Group, string> = {


### PR DESCRIPTION
## Summary
- `new Resend(process.env.RESEND_API_KEY)` at module level throws at Next.js build time when key is absent
- Moved initialization inside each handler, guarded by key check
- Affected: `/api/contact`, `/api/newsletter`, `/api/newsletter/unsubscribe`, `/api/cron/newsletter`
- Also removes colophon from command palette search

## Test plan
- [ ] CI unit+integration tests pass
- [ ] Vercel preview build succeeds without `RESEND_API_KEY`