### PR TITLE
perf: convert Footer and MainBanner to server components

### DIFF
--- a/app/components/banner.tsx
+++ b/app/components/banner.tsx
@@ -2,62 +2,7 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
-import { StatusCard } from './status'
 import { usePathname } from 'next/navigation'
-import profileData from 'content/profile.json'
-
-export function MainBanner({
-  name = profileData.name,
-  title = profileData.title,
-  location = profileData.location,
-}: {
-  name?: string
-  title?: string
-  location?: string
-} = {}) {
-  return (
-    <span className="dark:text-dark-text text-light-text smplus:flex-row smplus:justify-between mb-14 flex flex-col gap-6">
-      <div className="smplus:mb-0 mb-4 flex-none flex-row">
-        <Link
-          href={'https://gopalji.me'}
-          className="inline-flex flex-row gap-6"
-        >
-          <div className="relative w-12 min-w-12">
-            <Image
-              alt={name}
-              height={48}
-              width={48}
-              priority={true}
-              src="https://www.gravatar.com/avatar/0d634a9edf65bcc4916888473f10b1e6?size=200"
-              className="rounded-full bg-neutral-200 transition dark:bg-neutral-800 dark:brightness-90 dark:saturate-[0.85]"
-            />
-          </div>
-          <h1 className="relative mt-1 text-4xl font-semibold tracking-tight">
-            {name}
-          </h1>
-        </Link>
-        <h2 className="mt-6 text-2xl tracking-tight">
-          <p className="from-dark-secondary to-dark-primary inline-block bg-gradient-to-tr bg-clip-text leading-normal font-semibold text-transparent">
-            {title}
-          </p>
-          <br></br>
-          based in {location}.
-        </h2>
-      </div>
-      {/*<div className="flex-1 content-center min-w-[128px] justify-items-start sm:justify-items-end mb-4 sm:mb-0">*/}
-      {/*    <Image*/}
-      {/*        alt='Gopalji Gaur'*/}
-      {/*        height={128}*/}
-      {/*        width={128}*/}
-      {/*        priority={true}*/}
-      {/*        src='https://www.gravatar.com/avatar/0d634a9edf65bcc4916888473f10b1e6?size=200'*/}
-      {/*        className="rounded-full bg-neutral-200 dark:bg-neutral-800 dark:brightness-90 dark:saturate-[0.85] transition"*/}
-      {/*    />*/}
-      {/*</div>*/}
-      <StatusCard />
-    </span>
-  )
-}
 
 export function Banner() {
   const pathname = usePathname()

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,8 +1,6 @@
-'use client'
-
 import Link from 'next/link'
-import { usePathname, useRouter } from 'next/navigation'
 import { profile } from 'app/lib/profile'
+import { NewsletterFooterButton } from 'app/components/newsletter-footer-button'
 
 export function ArrowIcon() {
   return (
@@ -23,9 +21,6 @@ export function ArrowIcon() {
 }
 
 export default function Footer() {
-  const pathname = usePathname()
-  const router = useRouter()
-
   return (
     <footer className="pt-8 pb-12">
       <div className="font-sm text-secondary-inv mt-8 flex items-center">
@@ -73,20 +68,7 @@ export default function Footer() {
             </a>
           </li>
           <li>
-            <button
-              onClick={() => {
-                if (pathname === '/') {
-                  window.dispatchEvent(new Event('openNewsletter'))
-                } else {
-                  sessionStorage.setItem('newsletter_highlight', '1')
-                  router.push('/')
-                }
-              }}
-              className="flex cursor-pointer items-center transition-all hover:text-neutral-800 focus-visible:text-neutral-800 focus-visible:outline-none dark:hover:text-neutral-100 dark:focus-visible:text-neutral-100"
-            >
-              <ArrowIcon />
-              <span className="ml-2">newsletter</span>
-            </button>
+            <NewsletterFooterButton />
           </li>
           <li>
             <Link

--- a/app/components/main-banner.tsx
+++ b/app/components/main-banner.tsx
@@ -1,0 +1,47 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { StatusCard } from './status'
+import profileData from 'content/profile.json'
+
+export function MainBanner({
+  name = profileData.name,
+  title = profileData.title,
+  location = profileData.location,
+}: {
+  name?: string
+  title?: string
+  location?: string
+} = {}) {
+  return (
+    <span className="dark:text-dark-text text-light-text smplus:flex-row smplus:justify-between mb-14 flex flex-col gap-6">
+      <div className="smplus:mb-0 mb-4 flex-none flex-row">
+        <Link
+          href={'https://gopalji.me'}
+          className="inline-flex flex-row gap-6"
+        >
+          <div className="relative w-12 min-w-12">
+            <Image
+              alt={name}
+              height={48}
+              width={48}
+              priority={true}
+              src="https://www.gravatar.com/avatar/0d634a9edf65bcc4916888473f10b1e6?size=200"
+              className="rounded-full bg-neutral-200 transition dark:bg-neutral-800 dark:brightness-90 dark:saturate-[0.85]"
+            />
+          </div>
+          <h1 className="relative mt-1 text-4xl font-semibold tracking-tight">
+            {name}
+          </h1>
+        </Link>
+        <h2 className="mt-6 text-2xl tracking-tight">
+          <p className="from-dark-secondary to-dark-primary inline-block bg-gradient-to-tr bg-clip-text leading-normal font-semibold text-transparent">
+            {title}
+          </p>
+          <br></br>
+          based in {location}.
+        </h2>
+      </div>
+      <StatusCard />
+    </span>
+  )
+}

--- a/app/components/newsletter-footer-button.tsx
+++ b/app/components/newsletter-footer-button.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { usePathname, useRouter } from 'next/navigation'
+import { ArrowIcon } from 'app/components/footer'
+
+export function NewsletterFooterButton() {
+  const pathname = usePathname()
+  const router = useRouter()
+
+  return (
+    <button
+      onClick={() => {
+        if (pathname === '/') {
+          window.dispatchEvent(new Event('openNewsletter'))
+        } else {
+          sessionStorage.setItem('newsletter_highlight', '1')
+          router.push('/')
+        }
+      }}
+      className="flex cursor-pointer items-center transition-all hover:text-neutral-800 focus-visible:text-neutral-800 focus-visible:outline-none dark:hover:text-neutral-100 dark:focus-visible:text-neutral-100"
+    >
+      <ArrowIcon />
+      <span className="ml-2">newsletter</span>
+    </button>
+  )
+}

--- a/app/home-client.tsx
+++ b/app/home-client.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useTina } from 'tinacms/dist/react'
-import { MainBanner } from 'app/components/banner'
+import { MainBanner } from 'app/components/main-banner'
 import { NewsletterSection } from 'app/components/newsletter-section'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import { MainBanner } from 'app/components/banner'
+import { MainBanner } from 'app/components/main-banner'
 import { profile } from 'app/lib/profile'
 import { NewsletterSection } from 'app/components/newsletter-section'
 import HomeClient from './home-client'


### PR DESCRIPTION
## Summary
- `Footer` converted to server component — removes `usePathname`/`useRouter` hydration cost from every page's root layout
- `MainBanner` split into its own file (`main-banner.tsx`) as a server component — LCP avatar image `priority` preload now emits at server render time instead of waiting for hydration
- Newsletter button extracted to thin `NewsletterFooterButton` client wrapper (the only interactive piece in footer)

## Test plan
- [ ] Home page loads, avatar image and banner render correctly
- [ ] Footer links work (github, linkedin, email, resume, colophon)
- [ ] Footer newsletter button dispatches event on `/` and redirects with sessionStorage flag on other pages
- [ ] Blog/misc/projects banner renders correctly