### PR TITLE
feat: migrate gist embed to GitHub Gists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ This issue only affects the TinaCMS dev path. The MDX/production path (`mdx.tsx`
 
 Used in blog posts (`app/blog/posts/*.mdx`) and registered in both `app/components/mdx.tsx` (static path) and `app/blog/[slug]/blog-post-client.tsx` (TinaCMS path):
 
-- `<OpenGistCode url="..." />` — fetches and renders a GitHub Gist with syntax highlighting
+- `<GistCode url="..." />` — fetches and renders a GitHub Gist with syntax highlighting
 - `<VibeSimulator />` — interactive AI app builder widget
 - `<Callout type="note|warning|tip" content="..." />` — styled callout. Use the `content` prop (not children) so it works in both the static MDX path and TinaCMS's template renderer.
 

--- a/app/api/gist/route.ts
+++ b/app/api/gist/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const url = req.nextUrl.searchParams.get('url')
+  if (!url || !url.startsWith('https://gist.github.com/')) {
+    return NextResponse.json({ error: 'Invalid URL' }, { status: 400 })
+  }
+
+  // Extract gist ID from URL: https://gist.github.com/{user}/{id}
+  const gistId = url.split('/').pop()
+  if (!gistId) {
+    return NextResponse.json({ error: 'Invalid URL' }, { status: 400 })
+  }
+
+  const res = await fetch(`https://api.github.com/gists/${gistId}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    next: { revalidate: 3600 },
+  })
+
+  if (!res.ok) {
+    return NextResponse.json({ error: 'Fetch failed' }, { status: res.status })
+  }
+
+  const data = await res.json()
+
+  // GitHub REST API returns files as object keyed by filename; normalize to array
+  const files = Object.values(data.files ?? {}) as {
+    filename: string
+    content: string
+    language: string
+  }[]
+
+  return NextResponse.json({ files })
+}

--- a/app/blog/[slug]/blog-post-client.tsx
+++ b/app/blog/[slug]/blog-post-client.tsx
@@ -10,7 +10,7 @@ import Comments from 'app/components/comments'
 import { TableOfContents } from 'app/components/toc'
 import { RelatedPosts } from 'app/components/related-posts'
 import { formatDate, slugify } from 'app/blog/utils.shared'
-import { Code, OpenGistCode } from 'app/components/code'
+import { Code, GistCode } from 'app/components/code'
 import { VibeSimulator } from 'app/components/vibe-simulator'
 import { Callout } from 'app/components/callout'
 import { LinkPreview } from 'app/components/link-preview'
@@ -86,7 +86,7 @@ const baseTinaComponents: Record<string, any> = {
     type?: 'note' | 'warning' | 'tip'
     content?: string
   }) => <Callout type={type}>{content}</Callout>,
-  OpenGistCode: ({ url }: { url: string }) => <OpenGistCode url={url} />,
+  GistCode: ({ url }: { url: string }) => <GistCode url={url} />,
 }
 
 interface BlogPostClientProps {

--- a/app/blog/posts/static-typing.mdx
+++ b/app/blog/posts/static-typing.mdx
@@ -22,7 +22,7 @@ function greet(name: string): string {
 let message: string = greet(123)
 ```
 
-<OpenGistCode url="https://gist.gopalji.me/gopalji/be5b67d60529485881a7d32d6dc2acd5#file-test-py" />
+<GistCode url="https://gist.github.com/gopaljigaur/8673b50fa8616274e845d10b8d55ba68#file-test-py" />
 
 ## Enhanced Readability and Maintainability
 

--- a/app/components/code.tsx
+++ b/app/components/code.tsx
@@ -9,14 +9,14 @@ import { jsx, jsxs } from 'react/jsx-runtime'
 import { GoCopy, GoCheck, GoArrowUpRight } from 'react-icons/go'
 import type { Root, RootContent } from 'hast'
 
-interface OpenGistCodeProps {
+interface GistCodeProps {
   url: string
 }
 
 interface GistFile {
   filename: string
   content: string
-  type: string
+  language: string
 }
 
 interface GistData {
@@ -79,15 +79,11 @@ export function Code({ children, ...props }) {
 }
 
 const fetchGistCode = async (url: string) => {
-  // Parse URL to get the hash fragment (e.g., #file-test-py)
   const urlParts = url.split('#')
   const baseUrl = urlParts[0]
-  const fileHash = urlParts[1] // e.g., "file-test-py"
+  const fileHash = urlParts[1]
 
-  // Fetch the JSON (base URL + .json)
-  const jsonUrl = `${baseUrl}.json`
-
-  const response = await fetch(jsonUrl)
+  const response = await fetch(`/api/gist?url=${encodeURIComponent(baseUrl)}`)
 
   if (!response.ok) {
     throw new Error(`Failed to fetch: ${response.status}`)
@@ -119,7 +115,7 @@ const fetchGistCode = async (url: string) => {
   }
 }
 
-export function OpenGistCode({ url }: OpenGistCodeProps) {
+export function GistCode({ url }: GistCodeProps) {
   const { data, error, isLoading } = useSWR(url, fetchGistCode, {
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
@@ -172,7 +168,9 @@ export function OpenGistCode({ url }: OpenGistCodeProps) {
           </div>
           {/* Code block */}
           <pre className="!m-0 !rounded-none">
-            <Code language={file.type.toLowerCase()}>{file.content}</Code>
+            <Code language={(file.language ?? 'text').toLowerCase()}>
+              {file.content}
+            </Code>
           </pre>
         </div>
       ))}

--- a/app/components/mdx.tsx
+++ b/app/components/mdx.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { MDXRemote } from 'next-mdx-remote/rsc'
 import React from 'react'
-import { Code, OpenGistCode } from 'app/components/code'
+import { Code, GistCode } from 'app/components/code'
 import { VibeSimulator } from 'app/components/vibe-simulator'
 import { Callout } from 'app/components/callout'
 import { PostPreviewLink } from 'app/components/post-preview-link'
@@ -116,7 +116,7 @@ const components = {
   table: Table,
   VibeSimulator,
   Callout,
-  OpenGistCode,
+  GistCode,
 }
 
 export function CustomMDX(props) {

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -133,7 +133,7 @@ export default defineConfig({
                 ],
               },
               {
-                name: 'OpenGistCode',
+                name: 'GistCode',
                 label: 'GitHub Gist',
                 fields: [
                   {

--- a/tina/tina-lock.json
+++ b/tina/tina-lock.json
@@ -242,7 +242,7 @@
                 "namespace": ["blog", "body", "Callout"]
               },
               {
-                "name": "OpenGistCode",
+                "name": "GistCode",
                 "label": "GitHub Gist",
                 "fields": [
                   {
@@ -250,12 +250,12 @@
                     "name": "url",
                     "label": "Gist URL",
                     "required": true,
-                    "namespace": ["blog", "body", "OpenGistCode", "url"],
+                    "namespace": ["blog", "body", "GistCode", "url"],
                     "searchable": true,
                     "uid": false
                   }
                 ],
-                "namespace": ["blog", "body", "OpenGistCode"]
+                "namespace": ["blog", "body", "GistCode"]
               }
             ],
             "namespace": ["blog", "body"],
@@ -2223,7 +2223,7 @@
       },
       {
         "kind": "InputObjectTypeDefinition",
-        "name": { "kind": "Name", "value": "BlogBodyOpenGistCodeFilter" },
+        "name": { "kind": "Name", "value": "BlogBodyGistCodeFilter" },
         "fields": [
           {
             "kind": "InputValueDefinition",
@@ -2257,10 +2257,10 @@
           },
           {
             "kind": "InputValueDefinition",
-            "name": { "kind": "Name", "value": "OpenGistCode" },
+            "name": { "kind": "Name", "value": "GistCode" },
             "type": {
               "kind": "NamedType",
-              "name": { "kind": "Name", "value": "BlogBodyOpenGistCodeFilter" }
+              "name": { "kind": "Name", "value": "BlogBodyGistCodeFilter" }
             }
           }
         ]


### PR DESCRIPTION
## Summary
- Rename `OpenGistCode` → `GistCode` across all files (component, MDX, TinaCMS config, docs)
- Replace self-hosted OpenGist URL with GitHub Gist URL in `static-typing.mdx`
- Add `/api/gist` proxy route to avoid CORS (GitHub Gist API doesn't set `Access-Control-Allow-Origin`)
- Use GitHub REST API (`api.github.com/gists/{id}`) instead of `.json` web endpoint for reliable format
- Use `language` field (e.g. "Python") instead of MIME `type` field for Shiki syntax highlighting

## Test plan
- [ ] Visit `/blog/static-typing` — gist block renders with Python syntax highlighting
- [ ] "open gist" link points to correct GitHub Gist URL
- [ ] No CORS errors in console