### PR TITLE
feat: add model fallback chain for chat and vibe coder

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -9,10 +9,45 @@ const MAX_MESSAGES = 10 // keep last 10 messages (5 turns)
 const RATE_LIMIT = 20 // requests per IP per hour
 const CACHE_TTL = 86400 // 24 hours in seconds
 
-const GEMINI_URL = (streaming: boolean) =>
-  `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:${
+const GEMINI_MODELS = [
+  'gemini-3-flash-preview',
+  'gemini-2.5-flash',
+  'gemini-3.1-flash-lite-preview',
+]
+
+const geminiUrl = (model: string, streaming: boolean) =>
+  `https://generativelanguage.googleapis.com/v1beta/models/${model}:${
     streaming ? 'streamGenerateContent?alt=sse&' : 'generateContent?'
   }key=${process.env.GEMINI_API_KEY}`
+
+// Retry on quota/overload errors, fail fast on bad requests
+const RETRYABLE = new Set([429, 500, 503])
+
+async function geminiJson(body: unknown): Promise<Response> {
+  for (const model of GEMINI_MODELS) {
+    const res = await fetch(geminiUrl(model, false), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (res.ok) return res
+    if (!RETRYABLE.has(res.status)) return res
+  }
+  return new Response('All models unavailable', { status: 503 })
+}
+
+async function geminiStream(body: unknown): Promise<Response> {
+  for (const model of GEMINI_MODELS) {
+    const res = await fetch(geminiUrl(model, true), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (res.ok) return res
+    if (!RETRYABLE.has(res.status)) return res
+  }
+  return new Response('All models unavailable', { status: 503 })
+}
 
 const TOOLS = [
   {
@@ -188,14 +223,10 @@ async function handleChat(request: NextRequest) {
   }
 
   // Phase 1: non-streaming — detect tool call
-  const phase1Res = await fetch(GEMINI_URL(false), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      system_instruction: { parts: [{ text: SYSTEM_PROMPT }] },
-      contents: messages,
-      tools: TOOLS,
-    }),
+  const phase1Res = await geminiJson({
+    system_instruction: { parts: [{ text: SYSTEM_PROMPT }] },
+    contents: messages,
+    tools: TOOLS,
   })
 
   if (!phase1Res.ok) return new Response('Upstream error', { status: 502 })
@@ -266,13 +297,9 @@ async function handleChat(request: NextRequest) {
   ]
 
   // Phase 2: stream to client, accumulate for cache
-  const phase2Res = await fetch(GEMINI_URL(true), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      system_instruction: { parts: [{ text: SYSTEM_PROMPT }] },
-      contents: contentsWithTool,
-    }),
+  const phase2Res = await geminiStream({
+    system_instruction: { parts: [{ text: SYSTEM_PROMPT }] },
+    contents: contentsWithTool,
   })
 
   if (!phase2Res.ok) return new Response('Upstream error', { status: 502 })

--- a/app/api/generate-code/route.ts
+++ b/app/api/generate-code/route.ts
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest) {
     }
 
     const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite-preview:generateContent?key=${apiKey}`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Chat API tries models in order: `gemini-3-flash-preview` → `gemini-2.5-flash` → `gemini-3.1-flash-lite-preview` on 429/500/503
- VibeSimulator `/api/generate-code` pinned to `gemini-3.1-flash-lite-preview` (no fallback needed)

## Test plan
- [ ] Chat widget responds normally
- [ ] VibeSimulator generates code