### PR TITLE
blog: The Tool Registry Is the Heart of Your Agent

### DIFF
--- a/app/blog/[slug]/blog-post-client.tsx
+++ b/app/blog/[slug]/blog-post-client.tsx
@@ -13,6 +13,8 @@ import { formatDate, slugify } from 'app/blog/utils.shared'
 import { Code, GistCode } from 'app/components/code'
 import { VibeSimulator } from 'app/components/vibe-simulator'
 import { Callout } from 'app/components/callout'
+import { StatCallout } from 'app/components/stat-callout'
+import { LabeledCode } from 'app/components/labeled-code'
 import { LinkPreview } from 'app/components/link-preview'
 import { PostPreviewLink } from 'app/components/post-preview-link'
 import type { BlogPost, Heading } from 'app/blog/utils.shared'
@@ -87,6 +89,31 @@ const baseTinaComponents: Record<string, any> = {
     content?: string
   }) => <Callout type={type}>{content}</Callout>,
   GistCode: ({ url }: { url: string }) => <GistCode url={url} />,
+  StatCallout: ({
+    stat,
+    label,
+    source,
+    sourceUrl,
+  }: {
+    stat: string
+    label: string
+    source?: string
+    sourceUrl?: string
+  }) => (
+    <StatCallout
+      stat={stat}
+      label={label}
+      source={source}
+      sourceUrl={sourceUrl}
+    />
+  ),
+  LabeledCode: ({
+    type,
+    label,
+  }: {
+    type?: 'good' | 'bad' | 'note'
+    label: string
+  }) => <LabeledCode type={type} label={label} />,
 }
 
 interface BlogPostClientProps {

--- a/app/blog/[slug]/blog-post-client.tsx
+++ b/app/blog/[slug]/blog-post-client.tsx
@@ -15,6 +15,12 @@ import { VibeSimulator } from 'app/components/vibe-simulator'
 import { Callout } from 'app/components/callout'
 import { StatCallout } from 'app/components/stat-callout'
 import { LabeledCode } from 'app/components/labeled-code'
+import { ToolDescriptionGrader } from 'app/components/tool-description-grader'
+import { ToolScaleSimulator } from 'app/components/tool-scale-simulator'
+import { VerbosityBiasDemo } from 'app/components/verbosity-bias-demo'
+import { EvalCoverageMatrix } from 'app/components/eval-coverage-matrix'
+import { ConsistencyTradeoffExplorer } from 'app/components/consistency-tradeoff-explorer'
+import { BenchmarkBlindspots } from 'app/components/benchmark-blindspots'
 import { LinkPreview } from 'app/components/link-preview'
 import { PostPreviewLink } from 'app/components/post-preview-link'
 import type { BlogPost, Heading } from 'app/blog/utils.shared'
@@ -114,6 +120,12 @@ const baseTinaComponents: Record<string, any> = {
     type?: 'good' | 'bad' | 'note'
     label: string
   }) => <LabeledCode type={type} label={label} />,
+  ToolDescriptionGrader: () => <ToolDescriptionGrader />,
+  ToolScaleSimulator: () => <ToolScaleSimulator />,
+  VerbosityBiasDemo: () => <VerbosityBiasDemo />,
+  EvalCoverageMatrix: () => <EvalCoverageMatrix />,
+  ConsistencyTradeoffExplorer: () => <ConsistencyTradeoffExplorer />,
+  BenchmarkBlindspots: () => <BenchmarkBlindspots />,
 }
 
 interface BlogPostClientProps {

--- a/app/blog/posts/tool-registry-agents.mdx
+++ b/app/blog/posts/tool-registry-agents.mdx
@@ -29,6 +29,8 @@ This worked when demos had three tools. Production agents have thirty.
   sourceUrl="https://arxiv.org/html/2602.14878v1"
 />
 
+<ToolScaleSimulator />
+
 The tools themselves are not broken. The descriptions are. They are the only signal the LLM has when deciding which capability to invoke, and they are almost universally deficient. Frameworks hide this behind abstraction. You ship, it works in testing, and you never audit the thing the model is actually reading.
 
 ## Three ways the tool layer breaks
@@ -139,3 +141,5 @@ The frameworks that survive the current consolidation will be the ones that buil
 Agents fail at the tool boundary more often than they fail at the orchestration boundary.
 
 The tool descriptions in your current agent: when did you last read them? Not the code. The strings the model actually reads. That is probably the right place to start.
+
+<ToolDescriptionGrader />

--- a/app/blog/posts/tool-registry-agents.mdx
+++ b/app/blog/posts/tool-registry-agents.mdx
@@ -12,60 +12,105 @@ tags:
 
 Somewhere around tool number eight, the agent starts hallucinating function names.
 
-Not the model. Not the orchestration. Your agent starts calling `create_entry_record` — a function that doesn't exist — because you added three more MCP servers last Tuesday, and the tool list grew past the point where the LLM can reliably distinguish between `add_sales_contact`, `log_interaction`, and `record_outreach`. The tool descriptions were written in ten minutes as docstrings. Nobody thought of them as a retrieval surface. Now an agent is calling phantom functions and your on-call engineer is blaming GPT.
+Your agent starts calling `create_entry_record` — a function that doesn't exist — because you added three more MCP servers last Tuesday and the tool list grew past the point where the LLM can reliably distinguish between `add_sales_contact`, `log_interaction`, and `record_outreach`. The tool descriptions were written in ten minutes as docstrings. Nobody thought of them as a retrieval surface. Now an agent is calling phantom functions and your on-call engineer is blaming GPT.
 
-I've spent several months building [Cyclops](https://github.com/gopaljigaur/cyclops), a lightweight agent framework with a focus on explicit tool registry management, and the single most consistent lesson is this: **the tool registry is the most important architectural decision in an agent system, and almost every framework treats it as an afterthought.**
+I've spent several months building [Cyclops](https://github.com/gopaljigaur/cyclops), a lightweight agent framework with explicit tool registry management, and the single most consistent lesson has been this: **the tool registry is the most important architectural decision in an agent system, and almost every framework treats it as an afterthought.**
 
 ## What frameworks actually ship
 
-LangChain wraps tools in a `Tool` object and injects their descriptions into a big prompt block. LangGraph gives you more control over state transitions but the tool exposure surface works the same way — serialize everything, send everything, hope the model figures out which one to call. The OpenAI Agents SDK (released March 11, 2025, as the production successor to Swarm) is genuinely cleaner than its predecessors, but still operates on the flat-list mental model: you define tools, the SDK includes them all in every call, forever.
+[LangChain](https://python.langchain.com/docs/concepts/tools/) wraps tools in a `Tool` object and injects their descriptions into a big prompt block. [LangGraph](https://langchain-ai.github.io/langgraph/) gives you more control over state transitions but the tool exposure surface works the same way: serialize everything, send everything, hope the model figures out which one to call. The [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) (released March 2025 as the production successor to Swarm) is genuinely cleaner than its predecessors but still operates on the flat-list mental model. You define tools; the SDK includes them all in every call, forever.
 
 This worked when demos had three tools. Production agents have thirty.
 
-A [2025 paper analyzing MCP tool descriptions](https://arxiv.org/html/2602.14878v1) across the public ecosystem found that 97.1% of tool descriptions contain at least one quality issue, with more than half having unclear purpose statements. The tools themselves aren't broken. The descriptions — which are the only signal the LLM has when deciding which capability to invoke — are almost universally deficient. Frameworks hide this behind abstraction. You ship, it works in testing, and you never audit the thing the model is actually reading.
+A [2025 paper analyzing MCP tool descriptions](https://arxiv.org/html/2602.14878v1) across the public ecosystem found that **97.1% of tool descriptions contain at least one quality issue**, with more than half having unclear purpose statements. The tools themselves aren't broken. The descriptions — the only signal the LLM has when deciding which capability to invoke — are almost universally deficient. Frameworks hide this behind abstraction. You ship, it works in testing, and you never audit the thing the model is actually reading.
 
 ## Three ways the tool layer breaks in production
 
-When you present a model with too many tools simultaneously, three distinct failure modes appear. I've hit all three.
+When you give a model too many tools simultaneously, three distinct failure modes appear. I've hit all three building Cyclops.
 
-The first is incorrect tool selection: the model picks something adjacent but semantically close enough that nothing crashes. You have `get_user_profile` and `fetch_user_data` in the registry with subtly different scopes. The model picks based on token similarity. It returns data — just the wrong data. No exception raised. This one is invisible until a human notices the output is wrong.
+**Incorrect tool selection.** The model picks something adjacent but close enough that nothing crashes. You have `get_user_profile` and `fetch_user_data` in the registry with subtly different scopes. The model picks based on token similarity, returns data — just the wrong data. No exception raised. Invisible until a human notices.
 
-The second is parameter hallucination. The model calls the right tool with invented arguments. Your `search_documents` schema expects `date_start` and `date_end`; the model passes `{"time_range": "last_quarter"}` because that phrasing appeared in the task description. With strict Structured Outputs enforcement (available since `gpt-4o`), this becomes a schema validation error. Without it, the field gets silently ignored, or your tool crashes, or you get results filtered to nothing.
+**Parameter hallucination.** The model calls the right tool with invented arguments. Your `search_documents` schema expects `date_start` and `date_end`; the model passes `{"time_range": "last_quarter"}` because that phrasing appeared in the task description. With [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs) enforcement this becomes a schema validation error. Without it, the field is silently ignored and you get results filtered to nothing.
 
-The third is tool interference. When tools have overlapping semantic territory, the model chains them incorrectly or skips ones that should run. Watching Cyclops call a summarization tool mid-retrieval — because the retrieved document chunk mentioned "summary needed" — was clarifying. The model wasn't confused about the task. It was confused about which capabilities mapped to which parts of the task, because two tools had descriptions that overlapped in that corner case.
+**Tool interference.** When tools have overlapping semantic territory, the model chains them incorrectly. Watching Cyclops call a summarization tool mid-retrieval, because a retrieved document chunk mentioned "summary needed," was clarifying. The model wasn't confused about the task. It was confused about which capabilities mapped to which parts of the task, because two descriptions overlapped in that one corner case.
 
-Old `gpt-4` had less than 40% schema compliance when tool schemas weren't enforced. Modern models have improved enormously on parameter hallucination specifically. `gpt-4o` with Structured Outputs achieves 100% schema-valid outputs. But that only solves problem two. Incorrect selection and interference are semantic problems — constrained decoding can't fix them because the model is choosing correctly within the schema, just picking the wrong tool in the first place.
+Old `gpt-4` had less than 40% schema compliance when schemas weren't enforced. Modern models with `gpt-4o` Structured Outputs achieve 100% schema-valid outputs. That only fixes problem two. Incorrect selection and interference are semantic problems. Constrained decoding can't fix them.
 
 ## A registry is not a list
 
-Here's the shift: a tool registry isn't a list — it's a queryable, runtime-aware index of capabilities.
+Here's the shift: **a tool registry is a queryable, runtime-aware index of capabilities**, not a list.
 
-In Cyclops, tools don't get injected wholesale into every agent prompt. The registry holds them. When the orchestrator needs to act, it queries the registry given the current task context, retrieves a scoped subset — typically five to eight tools — and that's what the LLM sees. Selection accuracy goes up. Token budget for descriptions shrinks. And tool descriptions become something you actively maintain, because they're the retrieval key, not just documentation nobody reads.
+In Cyclops, tools don't get injected wholesale into every agent prompt. The registry holds them. When the orchestrator needs to act, it queries the registry given the current task context, retrieves a scoped subset of five to eight tools, and that's what the LLM sees. Selection accuracy goes up. Token budget for descriptions shrinks. Tool descriptions become something you actively maintain because they're the retrieval key, not documentation nobody reads.
 
-This is the same insight that made dense retrieval work for RAG. You don't dump your knowledge base into the context window. You retrieve relevant chunks. Your tool registry is a knowledge base of capabilities. Treat it with the engineering rigor you'd give a vector index.
+This is the same insight that made dense retrieval work for RAG. You don't dump your knowledge base into the context window. You retrieve relevant chunks. Your tool registry is a knowledge base of capabilities — treat it with the same engineering rigor you'd give a vector index.
 
-MCP makes this pattern structurally cleaner. Tools live in servers, servers can be queried at runtime, and tool lists can be dynamically scoped. [MCP-Zero](https://arxiv.org/html/2506.01056v3), published in 2025, goes further: instead of pulling a full tool manifest at agent startup, the agent actively requests tools when it needs them. Most MCP client implementations I've seen still pull the full list at connection time and inject all of it. They're using MCP as a fancier config file. The protocol supports something much more useful — they just haven't built it yet.
+[MCP](https://modelcontextprotocol.io/) makes this pattern structurally cleaner. Tools live in servers, servers can be queried at runtime, and tool lists can be dynamically scoped. [MCP-Zero](https://arxiv.org/html/2506.01056v3) (2025) goes further: instead of pulling a full manifest at agent startup, the agent actively requests tools when it needs them. Most MCP client implementations I've seen still pull the full list at connection time and inject all of it. They're using MCP as a fancier config file.
 
-In Cyclops, each tool registration includes the function signature, a semantic description, usage examples, and an explicit anti-pattern section: descriptions of what the tool should _not_ be used for. That last part sounds like over-engineering until you've watched an agent reach for `summarize_text` when it should reason directly, because the description said nothing to rule that case out.
+In Cyclops, each tool registration includes four things:
+
+```python
+registry.register(
+    fn=search_documents,
+    description="Search indexed documents by keyword or semantic query. Returns ranked chunks with source metadata.",
+    examples=[
+        "find all Q3 reports mentioning supply chain",
+        "search for emails about the Berlin office",
+    ],
+    anti_patterns=[
+        "Do NOT use for web search — use web_search() instead.",
+        "Do NOT use when the user wants a specific known document — use read_document().",
+    ],
+)
+```
+
+That `anti_patterns` field sounds like over-engineering until you've watched an agent reach for `summarize_text` when it should reason directly, because the description said nothing to rule that out.
 
 ## The description is the implementation
 
-This took me the longest to fully accept: **when building an agent, the tool description matters more than the tool implementation.**
+This took me the longest to accept: **when building an agent, the tool description matters more than the tool implementation.**
 
-A buggy tool that the agent calls at the right time with the right intent is recoverable. You fix the bug, redeploy. A well-implemented tool with an ambiguous description causes the agent to overuse it, underuse it, or combine it incorrectly — and that failure mode is much harder to diagnose because nothing throws an exception. The system produces wrong answers confidently.
+A buggy tool called at the right time with the right intent is recoverable — you fix the bug and redeploy. A well-implemented tool with an ambiguous description causes the agent to overuse it, underuse it, or chain it incorrectly, and that failure mode is much harder to diagnose because nothing throws an exception. The system produces wrong answers confidently.
 
-Anthropic's [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) research gets close to this point — the most successful agent implementations use simple, composable patterns — but doesn't push far enough on the tool layer specifically. "Simple" isn't about fewer lines of orchestration code. It's about unambiguous signal at every model decision point, and choosing which tool to call is the biggest decision an agent makes in a loop.
+Here's what a bad description looks like next to a good one:
 
-LiteLLM's MCP gateway gets this partially right by accident. It enforces access control at the tool level — a team or API key only sees the tools it's authorized to use — which happens to solve tool overload for multi-tenant scenarios as a side effect of authorization scoping. The right answer to the wrong question.
+```python
+# Causes selection errors
+description = "Gets data for a user."
 
-## What to actually do about this
+# Doesn't
+description = """
+Retrieves the full profile for a registered user — contact info,
+preferences, and account status. Requires a valid user_id.
 
-Write tool descriptions like API documentation for someone who's never seen your codebase. Then add a second paragraph explaining which adjacent tools this one is easily confused with, and why a developer should reach for this one instead of those. It feels tedious the first time. By tool fifteen, you will be grateful you did it.
+Use this when you need biographical or account-level information.
+Do NOT use for activity history — use get_user_activity() instead.
+Do NOT use for searching users by name or email — use search_users() instead.
+"""
+```
 
-Instrument tool selection explicitly. Log which tools the agent considered — not just which one it called. Without visibility into the selection process, you're debugging failures blindly: you see the wrong tool was called but can't tell whether the model was uncertain between candidates or confidently wrong. These require completely different interventions.
+[Anthropic's Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) research gets at this obliquely — the most successful implementations use simple, composable patterns — but doesn't push far enough on the tool layer. "Simple" isn't fewer lines of orchestration code. It's unambiguous signal at every model decision point.
 
-If you have more than ten tools registered, put a retrieval layer in front of the registry. This is not optional at scale — it's load-bearing architecture. The frameworks that survive the current consolidation will be the ones that build a first-class registry with retrieval semantics, not the ones with the most orchestration features.
+<Callout type="note" content="LiteLLM's MCP gateway enforces access control at the tool level — a team or API key only sees tools it's authorized to use. This happens to solve tool overload for multi-tenant scenarios as a side effect of scoping by authorization. Worth knowing about, even if it's the right answer to the wrong question." />
 
-Most current frameworks have the architecture inverted. They put significant engineering into the orchestration layer — how agents hand off to each other, how state flows between steps, how retries and timeouts work — while treating tool management as boilerplate. The orchestration layer matters. But agents fail at the tool boundary more often than they fail at the orchestration boundary.
+## What to actually do
+
+**Write descriptions like API docs for someone who has never seen your codebase.** Then add a paragraph explaining which adjacent tools this one is confused with, and why to reach for this one instead. Tedious the first time. Essential by tool fifteen.
+
+**Instrument tool selection explicitly.** Log which tools the agent *considered*, not just which one it called. Without this, you're debugging blind: you see the wrong tool was called but can't tell whether the model was uncertain or confidently wrong. These require completely different interventions.
+
+**Put a retrieval layer in front of the registry past ten tools.** This isn't optional at scale:
+
+```python
+# Instead of: agent sees all 30 tools every turn
+tools = registry.get_all()
+
+# Do this: agent sees only contextually relevant tools
+tools = registry.query(
+    context=current_task_description,
+    top_k=8,
+)
+```
+
+Most current frameworks have the architecture inverted: significant engineering in the orchestration layer — how agents hand off, how state flows, how retries work — while tool management is boilerplate. The orchestration layer matters. But agents fail at the tool boundary more often than they fail at the orchestration boundary.
 
 The tool descriptions in your current agent: when did you last read them? Not the code — the strings the model actually reads. That's probably the right place to start.

--- a/app/blog/posts/tool-registry-agents.mdx
+++ b/app/blog/posts/tool-registry-agents.mdx
@@ -1,0 +1,71 @@
+---
+title: 'The Tool Registry Is the Heart of Your Agent — Treat It That Way'
+publishedAt: '2026-04-22'
+summary: 'Most AI agent frameworks treat the tool layer as a config file. That single mistake explains why agents work in demos and collapse at tool number eight in production.'
+tags:
+  - ai
+  - agents
+  - mcp
+  - llm
+  - tools
+---
+
+Somewhere around tool number eight, the agent starts hallucinating function names.
+
+Not the model. Not the orchestration. Your agent starts calling `create_entry_record` — a function that doesn't exist — because you added three more MCP servers last Tuesday, and the tool list grew past the point where the LLM can reliably distinguish between `add_sales_contact`, `log_interaction`, and `record_outreach`. The tool descriptions were written in ten minutes as docstrings. Nobody thought of them as a retrieval surface. Now an agent is calling phantom functions and your on-call engineer is blaming GPT.
+
+I've spent several months building [Cyclops](https://github.com/gopaljigaur/cyclops), a lightweight agent framework with a focus on explicit tool registry management, and the single most consistent lesson is this: **the tool registry is the most important architectural decision in an agent system, and almost every framework treats it as an afterthought.**
+
+## What frameworks actually ship
+
+LangChain wraps tools in a `Tool` object and injects their descriptions into a big prompt block. LangGraph gives you more control over state transitions but the tool exposure surface works the same way — serialize everything, send everything, hope the model figures out which one to call. The OpenAI Agents SDK (released March 11, 2025, as the production successor to Swarm) is genuinely cleaner than its predecessors, but still operates on the flat-list mental model: you define tools, the SDK includes them all in every call, forever.
+
+This worked when demos had three tools. Production agents have thirty.
+
+A [2025 paper analyzing MCP tool descriptions](https://arxiv.org/html/2602.14878v1) across the public ecosystem found that 97.1% of tool descriptions contain at least one quality issue, with more than half having unclear purpose statements. The tools themselves aren't broken. The descriptions — which are the only signal the LLM has when deciding which capability to invoke — are almost universally deficient. Frameworks hide this behind abstraction. You ship, it works in testing, and you never audit the thing the model is actually reading.
+
+## Three ways the tool layer breaks in production
+
+When you present a model with too many tools simultaneously, three distinct failure modes appear. I've hit all three.
+
+The first is incorrect tool selection: the model picks something adjacent but semantically close enough that nothing crashes. You have `get_user_profile` and `fetch_user_data` in the registry with subtly different scopes. The model picks based on token similarity. It returns data — just the wrong data. No exception raised. This one is invisible until a human notices the output is wrong.
+
+The second is parameter hallucination. The model calls the right tool with invented arguments. Your `search_documents` schema expects `date_start` and `date_end`; the model passes `{"time_range": "last_quarter"}` because that phrasing appeared in the task description. With strict Structured Outputs enforcement (available since `gpt-4o`), this becomes a schema validation error. Without it, the field gets silently ignored, or your tool crashes, or you get results filtered to nothing.
+
+The third is tool interference. When tools have overlapping semantic territory, the model chains them incorrectly or skips ones that should run. Watching Cyclops call a summarization tool mid-retrieval — because the retrieved document chunk mentioned "summary needed" — was clarifying. The model wasn't confused about the task. It was confused about which capabilities mapped to which parts of the task, because two tools had descriptions that overlapped in that corner case.
+
+Old `gpt-4` had less than 40% schema compliance when tool schemas weren't enforced. Modern models have improved enormously on parameter hallucination specifically. `gpt-4o` with Structured Outputs achieves 100% schema-valid outputs. But that only solves problem two. Incorrect selection and interference are semantic problems — constrained decoding can't fix them because the model is choosing correctly within the schema, just picking the wrong tool in the first place.
+
+## A registry is not a list
+
+Here's the shift: a tool registry isn't a list — it's a queryable, runtime-aware index of capabilities.
+
+In Cyclops, tools don't get injected wholesale into every agent prompt. The registry holds them. When the orchestrator needs to act, it queries the registry given the current task context, retrieves a scoped subset — typically five to eight tools — and that's what the LLM sees. Selection accuracy goes up. Token budget for descriptions shrinks. And tool descriptions become something you actively maintain, because they're the retrieval key, not just documentation nobody reads.
+
+This is the same insight that made dense retrieval work for RAG. You don't dump your knowledge base into the context window. You retrieve relevant chunks. Your tool registry is a knowledge base of capabilities. Treat it with the engineering rigor you'd give a vector index.
+
+MCP makes this pattern structurally cleaner. Tools live in servers, servers can be queried at runtime, and tool lists can be dynamically scoped. [MCP-Zero](https://arxiv.org/html/2506.01056v3), published in 2025, goes further: instead of pulling a full tool manifest at agent startup, the agent actively requests tools when it needs them. Most MCP client implementations I've seen still pull the full list at connection time and inject all of it. They're using MCP as a fancier config file. The protocol supports something much more useful — they just haven't built it yet.
+
+In Cyclops, each tool registration includes the function signature, a semantic description, usage examples, and an explicit anti-pattern section: descriptions of what the tool should _not_ be used for. That last part sounds like over-engineering until you've watched an agent reach for `summarize_text` when it should reason directly, because the description said nothing to rule that case out.
+
+## The description is the implementation
+
+This took me the longest to fully accept: **when building an agent, the tool description matters more than the tool implementation.**
+
+A buggy tool that the agent calls at the right time with the right intent is recoverable. You fix the bug, redeploy. A well-implemented tool with an ambiguous description causes the agent to overuse it, underuse it, or combine it incorrectly — and that failure mode is much harder to diagnose because nothing throws an exception. The system produces wrong answers confidently.
+
+Anthropic's [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) research gets close to this point — the most successful agent implementations use simple, composable patterns — but doesn't push far enough on the tool layer specifically. "Simple" isn't about fewer lines of orchestration code. It's about unambiguous signal at every model decision point, and choosing which tool to call is the biggest decision an agent makes in a loop.
+
+LiteLLM's MCP gateway gets this partially right by accident. It enforces access control at the tool level — a team or API key only sees the tools it's authorized to use — which happens to solve tool overload for multi-tenant scenarios as a side effect of authorization scoping. The right answer to the wrong question.
+
+## What to actually do about this
+
+Write tool descriptions like API documentation for someone who's never seen your codebase. Then add a second paragraph explaining which adjacent tools this one is easily confused with, and why a developer should reach for this one instead of those. It feels tedious the first time. By tool fifteen, you will be grateful you did it.
+
+Instrument tool selection explicitly. Log which tools the agent considered — not just which one it called. Without visibility into the selection process, you're debugging failures blindly: you see the wrong tool was called but can't tell whether the model was uncertain between candidates or confidently wrong. These require completely different interventions.
+
+If you have more than ten tools registered, put a retrieval layer in front of the registry. This is not optional at scale — it's load-bearing architecture. The frameworks that survive the current consolidation will be the ones that build a first-class registry with retrieval semantics, not the ones with the most orchestration features.
+
+Most current frameworks have the architecture inverted. They put significant engineering into the orchestration layer — how agents hand off to each other, how state flows between steps, how retries and timeouts work — while treating tool management as boilerplate. The orchestration layer matters. But agents fail at the tool boundary more often than they fail at the orchestration boundary.
+
+The tool descriptions in your current agent: when did you last read them? Not the code — the strings the model actually reads. That's probably the right place to start.

--- a/app/blog/posts/tool-registry-agents.mdx
+++ b/app/blog/posts/tool-registry-agents.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'The Tool Registry Is the Heart of Your Agent — Treat It That Way'
+title: 'The Tool Registry Is the Heart of Your Agent: Treat It That Way'
 publishedAt: '2026-04-22'
 summary: 'Most AI agent frameworks treat the tool layer as a config file. That single mistake explains why agents work in demos and collapse at tool number eight in production.'
 tags:
@@ -55,7 +55,7 @@ Old `gpt-4` had less than 40% schema compliance when schemas were not enforced. 
 
 In Cyclops, tools do not get injected wholesale into every agent prompt. The registry holds them. When the orchestrator needs to act, it queries the registry given the current task context, retrieves a scoped subset of five to eight tools, and that is what the LLM sees. Selection accuracy goes up. Token budget for descriptions shrinks. Tool descriptions become something you actively maintain because they are the retrieval key, not documentation nobody reads.
 
-This is the same insight that made dense retrieval work for RAG. You do not dump your knowledge base into the context window. You retrieve relevant chunks. Your tool registry is a knowledge base of capabilities — treat it with the engineering rigor you would give a vector index.
+This is the same insight that made dense retrieval work for RAG. You do not dump your knowledge base into the context window. You retrieve relevant chunks. Your tool registry is a knowledge base of capabilities. Treat it with the engineering rigor you would give a vector index.
 
 [MCP](https://modelcontextprotocol.io/) makes this pattern structurally cleaner. Tools live in servers, servers can be queried at runtime, and tool lists can be dynamically scoped. [MCP-Zero](https://arxiv.org/html/2506.01056v3) (2025) goes further: instead of pulling a full manifest at agent startup, the agent actively requests tools when it needs them. Most MCP client implementations still pull the full list at connection time and inject all of it. They are using MCP as a fancier config file.
 
@@ -82,7 +82,7 @@ That `anti_patterns` field sounds like over-engineering until you have watched a
 
 **When building an agent, the tool description matters more than the tool implementation.**
 
-A buggy tool called at the right time with the right intent is recoverable — fix the bug, redeploy. A well-implemented tool with an ambiguous description causes the agent to overuse it, underuse it, or chain it incorrectly. That failure mode is much harder to diagnose because nothing throws an exception. The system produces wrong answers confidently.
+A buggy tool called at the right time with the right intent is recoverable. Fix the bug, redeploy. A well-implemented tool with an ambiguous description causes the agent to overuse it, underuse it, or chain it incorrectly. That failure mode is much harder to diagnose because nothing throws an exception. The system produces wrong answers confidently.
 
 Here is what the difference looks like in practice:
 
@@ -107,7 +107,7 @@ Do NOT use for searching users by name or email — use search_users() instead.
 """
 ```
 
-[Anthropic's Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) research gets close to this point — the most successful implementations use simple, composable patterns — but does not push far enough on the tool layer. "Simple" is not fewer lines of orchestration code. It is unambiguous signal at every model decision point, and choosing which tool to call is the biggest decision an agent makes in a loop.
+[Anthropic's Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) research gets close to this point (the most successful implementations use simple, composable patterns), but does not push far enough on the tool layer. "Simple" is not fewer lines of orchestration code. It is unambiguous signal at every model decision point, and choosing which tool to call is the biggest decision an agent makes in a loop.
 
 <Callout type="note" content="LiteLLM's MCP gateway enforces access control at the tool level: a team or API key only sees the tools it is authorized to use. This happens to solve tool overload for multi-tenant scenarios as a side effect of authorization scoping. Worth knowing about." />
 

--- a/app/blog/posts/tool-registry-agents.mdx
+++ b/app/blog/posts/tool-registry-agents.mdx
@@ -12,41 +12,54 @@ tags:
 
 Somewhere around tool number eight, the agent starts hallucinating function names.
 
-Your agent starts calling `create_entry_record` — a function that doesn't exist — because you added three more MCP servers last Tuesday and the tool list grew past the point where the LLM can reliably distinguish between `add_sales_contact`, `log_interaction`, and `record_outreach`. The tool descriptions were written in ten minutes as docstrings. Nobody thought of them as a retrieval surface. Now an agent is calling phantom functions and your on-call engineer is blaming GPT.
+Not the model. Not the orchestration. Your agent calls `create_entry_record`, a function that does not exist, because you added three more MCP servers last Tuesday and the tool list grew past the point where the LLM can reliably distinguish between `add_sales_contact`, `log_interaction`, and `record_outreach`. The tool descriptions were written in ten minutes as docstrings. Nobody thought of them as a retrieval surface. Now an agent is calling phantom functions and your on-call engineer is blaming GPT.
 
-I've spent several months building [Cyclops](https://github.com/gopaljigaur/cyclops), a lightweight agent framework with explicit tool registry management, and the single most consistent lesson has been this: **the tool registry is the most important architectural decision in an agent system, and almost every framework treats it as an afterthought.**
+I've spent several months building [Cyclops](https://github.com/gopaljigaur/cyclops), a lightweight agent framework with explicit tool registry management. The single most consistent lesson: **the tool registry is the most important architectural decision in an agent system, and almost every framework treats it as an afterthought.**
 
 ## What frameworks actually ship
 
-[LangChain](https://python.langchain.com/docs/concepts/tools/) wraps tools in a `Tool` object and injects their descriptions into a big prompt block. [LangGraph](https://langchain-ai.github.io/langgraph/) gives you more control over state transitions but the tool exposure surface works the same way: serialize everything, send everything, hope the model figures out which one to call. The [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) (released March 2025 as the production successor to Swarm) is genuinely cleaner than its predecessors but still operates on the flat-list mental model. You define tools; the SDK includes them all in every call, forever.
+[LangChain](https://python.langchain.com/docs/concepts/tools/) wraps tools in a `Tool` object and injects their descriptions into a big prompt block. [LangGraph](https://langchain-ai.github.io/langgraph/) gives you more state control but the tool exposure surface works the same way: serialize everything, send everything, hope the model picks right. The [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) (released March 2025, the production successor to Swarm) is genuinely cleaner, but still operates on the flat-list mental model. You define tools; the SDK includes them all in every call, forever.
 
 This worked when demos had three tools. Production agents have thirty.
 
-A [2025 paper analyzing MCP tool descriptions](https://arxiv.org/html/2602.14878v1) across the public ecosystem found that **97.1% of tool descriptions contain at least one quality issue**, with more than half having unclear purpose statements. The tools themselves aren't broken. The descriptions — the only signal the LLM has when deciding which capability to invoke — are almost universally deficient. Frameworks hide this behind abstraction. You ship, it works in testing, and you never audit the thing the model is actually reading.
+<StatCallout
+  stat="97.1%"
+  label="of MCP tool descriptions in the public ecosystem contain at least one quality issue, with more than half having unclear purpose statements"
+  source="arxiv.org/html/2602.14878v1"
+  sourceUrl="https://arxiv.org/html/2602.14878v1"
+/>
 
-## Three ways the tool layer breaks in production
+The tools themselves are not broken. The descriptions are. They are the only signal the LLM has when deciding which capability to invoke, and they are almost universally deficient. Frameworks hide this behind abstraction. You ship, it works in testing, and you never audit the thing the model is actually reading.
 
-When you give a model too many tools simultaneously, three distinct failure modes appear. I've hit all three building Cyclops.
+## Three ways the tool layer breaks
 
-**Incorrect tool selection.** The model picks something adjacent but close enough that nothing crashes. You have `get_user_profile` and `fetch_user_data` in the registry with subtly different scopes. The model picks based on token similarity, returns data — just the wrong data. No exception raised. Invisible until a human notices.
+When you give a model too many tools simultaneously, three distinct failure modes appear. I have hit all three building Cyclops.
 
-**Parameter hallucination.** The model calls the right tool with invented arguments. Your `search_documents` schema expects `date_start` and `date_end`; the model passes `{"time_range": "last_quarter"}` because that phrasing appeared in the task description. With [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs) enforcement this becomes a schema validation error. Without it, the field is silently ignored and you get results filtered to nothing.
+### Incorrect tool selection
 
-**Tool interference.** When tools have overlapping semantic territory, the model chains them incorrectly. Watching Cyclops call a summarization tool mid-retrieval, because a retrieved document chunk mentioned "summary needed," was clarifying. The model wasn't confused about the task. It was confused about which capabilities mapped to which parts of the task, because two descriptions overlapped in that one corner case.
+The model picks something adjacent but semantically close enough that nothing crashes. You have `get_user_profile` and `fetch_user_data` in the registry with subtly different scopes. The model picks based on token similarity, returns data. Just the wrong data. No exception raised. Invisible until a human notices the output is wrong.
 
-Old `gpt-4` had less than 40% schema compliance when schemas weren't enforced. Modern models with `gpt-4o` Structured Outputs achieve 100% schema-valid outputs. That only fixes problem two. Incorrect selection and interference are semantic problems. Constrained decoding can't fix them.
+### Parameter hallucination
+
+The model calls the right tool with invented arguments. Your `search_documents` schema expects `date_start` and `date_end`; the model passes `{"time_range": "last_quarter"}` because that phrasing appeared in the task description. With [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs) enforcement this becomes a schema validation error. Without it, the field gets silently ignored and you get results filtered to nothing.
+
+### Tool interference
+
+When tools have overlapping semantic territory, the model chains them incorrectly. Watching Cyclops call a summarization tool mid-retrieval, because a retrieved document chunk mentioned "summary needed," was clarifying. The model was not confused about the task. It was confused about which capabilities mapped to which parts of the task, because two descriptions overlapped in that corner case.
+
+Old `gpt-4` had less than 40% schema compliance when schemas were not enforced. Modern `gpt-4o` with Structured Outputs achieves 100% schema-valid outputs. That only fixes parameter hallucination. Incorrect selection and interference are semantic problems. Constrained decoding cannot fix them.
 
 ## A registry is not a list
 
-Here's the shift: **a tool registry is a queryable, runtime-aware index of capabilities**, not a list.
+**A tool registry is a queryable, runtime-aware index of capabilities.** Not a list.
 
-In Cyclops, tools don't get injected wholesale into every agent prompt. The registry holds them. When the orchestrator needs to act, it queries the registry given the current task context, retrieves a scoped subset of five to eight tools, and that's what the LLM sees. Selection accuracy goes up. Token budget for descriptions shrinks. Tool descriptions become something you actively maintain because they're the retrieval key, not documentation nobody reads.
+In Cyclops, tools do not get injected wholesale into every agent prompt. The registry holds them. When the orchestrator needs to act, it queries the registry given the current task context, retrieves a scoped subset of five to eight tools, and that is what the LLM sees. Selection accuracy goes up. Token budget for descriptions shrinks. Tool descriptions become something you actively maintain because they are the retrieval key, not documentation nobody reads.
 
-This is the same insight that made dense retrieval work for RAG. You don't dump your knowledge base into the context window. You retrieve relevant chunks. Your tool registry is a knowledge base of capabilities — treat it with the same engineering rigor you'd give a vector index.
+This is the same insight that made dense retrieval work for RAG. You do not dump your knowledge base into the context window. You retrieve relevant chunks. Your tool registry is a knowledge base of capabilities — treat it with the engineering rigor you would give a vector index.
 
-[MCP](https://modelcontextprotocol.io/) makes this pattern structurally cleaner. Tools live in servers, servers can be queried at runtime, and tool lists can be dynamically scoped. [MCP-Zero](https://arxiv.org/html/2506.01056v3) (2025) goes further: instead of pulling a full manifest at agent startup, the agent actively requests tools when it needs them. Most MCP client implementations I've seen still pull the full list at connection time and inject all of it. They're using MCP as a fancier config file.
+[MCP](https://modelcontextprotocol.io/) makes this pattern structurally cleaner. Tools live in servers, servers can be queried at runtime, and tool lists can be dynamically scoped. [MCP-Zero](https://arxiv.org/html/2506.01056v3) (2025) goes further: instead of pulling a full manifest at agent startup, the agent actively requests tools when it needs them. Most MCP client implementations still pull the full list at connection time and inject all of it. They are using MCP as a fancier config file.
 
-In Cyclops, each tool registration includes four things:
+In Cyclops, each tool registration includes four things: function signature, semantic description, usage examples, and an `anti_patterns` field:
 
 ```python
 registry.register(
@@ -63,54 +76,66 @@ registry.register(
 )
 ```
 
-That `anti_patterns` field sounds like over-engineering until you've watched an agent reach for `summarize_text` when it should reason directly, because the description said nothing to rule that out.
+That `anti_patterns` field sounds like over-engineering until you have watched an agent reach for `summarize_text` when it should reason directly, because the description said nothing to rule that out.
 
 ## The description is the implementation
 
-This took me the longest to accept: **when building an agent, the tool description matters more than the tool implementation.**
+**When building an agent, the tool description matters more than the tool implementation.**
 
-A buggy tool called at the right time with the right intent is recoverable — you fix the bug and redeploy. A well-implemented tool with an ambiguous description causes the agent to overuse it, underuse it, or chain it incorrectly, and that failure mode is much harder to diagnose because nothing throws an exception. The system produces wrong answers confidently.
+A buggy tool called at the right time with the right intent is recoverable — fix the bug, redeploy. A well-implemented tool with an ambiguous description causes the agent to overuse it, underuse it, or chain it incorrectly. That failure mode is much harder to diagnose because nothing throws an exception. The system produces wrong answers confidently.
 
-Here's what a bad description looks like next to a good one:
+Here is what the difference looks like in practice:
+
+<LabeledCode type="bad" label="Vague: causes phantom function calls and wrong tool selection" />
 
 ```python
-# Causes selection errors
 description = "Gets data for a user."
+```
 
-# Doesn't
+<LabeledCode type="good" label="Specific: purpose, required context, explicit anti-patterns" />
+
+```python
 description = """
-Retrieves the full profile for a registered user — contact info,
-preferences, and account status. Requires a valid user_id.
+Retrieves the full profile for a registered user: contact info,
+preferences, and account status. Requires a valid user_id from
+your session context.
 
-Use this when you need biographical or account-level information.
+Use when you need biographical or account-level information about
+a specific known user.
 Do NOT use for activity history — use get_user_activity() instead.
 Do NOT use for searching users by name or email — use search_users() instead.
 """
 ```
 
-[Anthropic's Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) research gets at this obliquely — the most successful implementations use simple, composable patterns — but doesn't push far enough on the tool layer. "Simple" isn't fewer lines of orchestration code. It's unambiguous signal at every model decision point.
+[Anthropic's Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) research gets close to this point — the most successful implementations use simple, composable patterns — but does not push far enough on the tool layer. "Simple" is not fewer lines of orchestration code. It is unambiguous signal at every model decision point, and choosing which tool to call is the biggest decision an agent makes in a loop.
 
-<Callout type="note" content="LiteLLM's MCP gateway enforces access control at the tool level — a team or API key only sees tools it's authorized to use. This happens to solve tool overload for multi-tenant scenarios as a side effect of scoping by authorization. Worth knowing about, even if it's the right answer to the wrong question." />
+<Callout type="note" content="LiteLLM's MCP gateway enforces access control at the tool level: a team or API key only sees the tools it is authorized to use. This happens to solve tool overload for multi-tenant scenarios as a side effect of authorization scoping. Worth knowing about." />
 
 ## What to actually do
 
-**Write descriptions like API docs for someone who has never seen your codebase.** Then add a paragraph explaining which adjacent tools this one is confused with, and why to reach for this one instead. Tedious the first time. Essential by tool fifteen.
+Write tool descriptions like API documentation for someone who has never seen your codebase. Then add a paragraph explaining which adjacent tools this one is confused with, and why to reach for this one instead. Tedious the first time. Essential by tool fifteen.
 
-**Instrument tool selection explicitly.** Log which tools the agent *considered*, not just which one it called. Without this, you're debugging blind: you see the wrong tool was called but can't tell whether the model was uncertain or confidently wrong. These require completely different interventions.
+Log which tools the agent *considered*, not just which one it called. Without this, debugging selection failures means you can see the wrong tool was called but cannot tell whether the model was uncertain between candidates or confidently wrong. These require completely different interventions.
 
-**Put a retrieval layer in front of the registry past ten tools.** This isn't optional at scale:
+Past ten tools, put a retrieval layer in front of the registry:
+
+<LabeledCode type="bad" label="Flat list: agent sees all 30 tools every turn" />
 
 ```python
-# Instead of: agent sees all 30 tools every turn
 tools = registry.get_all()
+```
 
-# Do this: agent sees only contextually relevant tools
+<LabeledCode type="good" label="Retrieval-scoped: agent sees only contextually relevant tools" />
+
+```python
 tools = registry.query(
     context=current_task_description,
     top_k=8,
 )
 ```
 
-Most current frameworks have the architecture inverted: significant engineering in the orchestration layer — how agents hand off, how state flows, how retries work — while tool management is boilerplate. The orchestration layer matters. But agents fail at the tool boundary more often than they fail at the orchestration boundary.
+The frameworks that survive the current consolidation will be the ones that build a first-class registry with retrieval semantics, not the ones with the most orchestration features. Most current frameworks have the architecture inverted: significant engineering in the orchestration layer, tool management treated as boilerplate.
 
-The tool descriptions in your current agent: when did you last read them? Not the code — the strings the model actually reads. That's probably the right place to start.
+Agents fail at the tool boundary more often than they fail at the orchestration boundary.
+
+The tool descriptions in your current agent: when did you last read them? Not the code. The strings the model actually reads. That is probably the right place to start.

--- a/app/components/benchmark-blindspots.tsx
+++ b/app/components/benchmark-blindspots.tsx
@@ -1,0 +1,133 @@
+'use client'
+import React from 'react'
+
+const SCENARIOS = [
+  {
+    scenario: 'Single subject, clean reference images',
+    note: 'The standard benchmark setup',
+    dinoI: true,
+    clipT: true,
+    dreamBench: true,
+    realWorld: false,
+  },
+  {
+    scenario: 'Multi-subject scene (3+ characters)',
+    note: 'Common production use case',
+    dinoI: false,
+    clipT: false,
+    dreamBench: false,
+    realWorld: true,
+  },
+  {
+    scenario: 'Subject in complex or novel background',
+    note: '',
+    dinoI: false,
+    clipT: true,
+    dreamBench: true,
+    realWorld: true,
+  },
+  {
+    scenario: 'Consistent character across a sequence',
+    note: 'Story, comic strip, product shoot',
+    dinoI: false,
+    clipT: false,
+    dreamBench: false,
+    realWorld: true,
+  },
+  {
+    scenario: 'Zero-shot generation (no fine-tuning)',
+    note: 'Hard constraint in many production pipelines',
+    dinoI: false,
+    clipT: false,
+    dreamBench: false,
+    realWorld: true,
+  },
+  {
+    scenario: 'Generated images as reference inputs',
+    note: 'Reference is itself slightly inconsistent',
+    dinoI: false,
+    clipT: false,
+    dreamBench: false,
+    realWorld: true,
+  },
+]
+
+function Cell({
+  covered,
+  productionCritical,
+}: {
+  covered: boolean
+  productionCritical: boolean
+}) {
+  if (covered)
+    return <span className="text-green-500 dark:text-green-400">✓</span>
+  if (productionCritical)
+    return <span className="font-bold text-red-500 dark:text-red-400">✗</span>
+  return <span className="text-neutral-200 dark:text-neutral-700">○</span>
+}
+
+export function BenchmarkBlindspots() {
+  return (
+    <div className="not-prose my-8 overflow-x-auto rounded-xl border border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <div className="p-5 pb-3">
+        <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+          Benchmark Coverage vs Real Scenarios
+        </p>
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">
+          Standard benchmarks cover the easy cases. Production breaks on the
+          rest.
+        </p>
+      </div>
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="border-t border-neutral-200 dark:border-neutral-800">
+            <th className="px-5 py-2.5 text-left font-medium text-neutral-500 dark:text-neutral-400">
+              Scenario
+            </th>
+            <th className="px-3 py-2.5 text-center font-medium text-neutral-500 dark:text-neutral-400">
+              DINO-I
+            </th>
+            <th className="px-3 py-2.5 text-center font-medium text-neutral-500 dark:text-neutral-400">
+              CLIP-T
+            </th>
+            <th className="px-3 py-2.5 text-center font-medium text-neutral-500 dark:text-neutral-400">
+              DreamBench
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {SCENARIOS.map((s) => (
+            <tr
+              key={s.scenario}
+              className="border-t border-neutral-100 dark:border-neutral-800/50"
+            >
+              <td className="px-5 py-2">
+                <span className="text-neutral-700 dark:text-neutral-300">
+                  {s.scenario}
+                </span>
+                {s.note && (
+                  <span className="ml-1.5 text-neutral-400 dark:text-neutral-600">
+                    ({s.note})
+                  </span>
+                )}
+              </td>
+              <td className="px-3 py-2 text-center">
+                <Cell covered={s.dinoI} productionCritical={s.realWorld} />
+              </td>
+              <td className="px-3 py-2 text-center">
+                <Cell covered={s.clipT} productionCritical={s.realWorld} />
+              </td>
+              <td className="px-3 py-2 text-center">
+                <Cell covered={s.dreamBench} productionCritical={s.realWorld} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="border-t border-neutral-100 px-5 py-3 text-xs text-neutral-400 dark:border-neutral-800 dark:text-neutral-600">
+        ✓ evaluated &nbsp;&nbsp; ✗ missing (production-critical) &nbsp;&nbsp; ○
+        not applicable
+      </p>
+    </div>
+  )
+}

--- a/app/components/consistency-tradeoff-explorer.tsx
+++ b/app/components/consistency-tradeoff-explorer.tsx
@@ -1,0 +1,112 @@
+'use client'
+import React, { useState } from 'react'
+
+const METHODS = [
+  {
+    label: 'Full fine-tuning',
+    sub: 'DreamBooth / LoRA per subject',
+    setup: 'Minutes to hours per subject',
+    fidelity: 95,
+    composability: 15,
+    flexibility: 5,
+    desc: 'Highest DINO-I scores. Strong texture reproduction. Each new subject needs its own fine-tune. LoRA fusion breaks down at 3+ subjects.',
+  },
+  {
+    label: 'Adapter-based',
+    sub: 'IP-Adapter-Plus style',
+    setup: 'Seconds at inference time',
+    fidelity: 72,
+    composability: 45,
+    flexibility: 60,
+    desc: 'Fast and flexible. Subject stays visually consistent at a glance. Complex prompt + subject compositions break. Text alignment degrades under load.',
+  },
+  {
+    label: 'Training-free',
+    sub: 'Masked cross-image attention',
+    setup: 'Zero — reference images at inference',
+    fidelity: 58,
+    composability: 80,
+    flexibility: 95,
+    desc: 'Zero-shot, any subject count, zero setup cost. Lower DINO-I. Attention leakage appears at 3+ subjects without masking. Benchmarks penalize this; users in practice often prefer it.',
+  },
+]
+
+const METRICS = [
+  {
+    key: 'fidelity',
+    label: 'Texture fidelity (what DINO-I measures)',
+    color: 'bg-blue-500',
+  },
+  {
+    key: 'composability',
+    label: 'Multi-subject composability',
+    color: 'bg-purple-500',
+  },
+  { key: 'flexibility', label: 'Zero-shot flexibility', color: 'bg-green-500' },
+] as const
+
+export function ConsistencyTradeoffExplorer() {
+  const [sel, setSel] = useState(0)
+  const method = METHODS[sel]
+
+  return (
+    <div className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+        Consistency Method Tradeoffs
+      </p>
+      <p className="mb-4 text-xs text-neutral-500 dark:text-neutral-400">
+        Each approach optimizes for a different axis. DINO-I only measures the
+        first one.
+      </p>
+
+      <div className="mb-4 flex gap-1.5">
+        {METHODS.map((m, i) => (
+          <button
+            key={m.label}
+            onClick={() => setSel(i)}
+            className={`flex-1 rounded-lg px-2 py-2 text-xs font-medium transition-colors ${
+              sel === i
+                ? 'bg-neutral-900 text-white dark:bg-white dark:text-neutral-900'
+                : 'border border-neutral-200 text-neutral-600 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-800'
+            }`}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mb-4 rounded-lg border border-neutral-200 bg-white p-3 dark:border-neutral-700 dark:bg-neutral-950">
+        <p className="mb-0.5 text-xs font-medium text-neutral-700 dark:text-neutral-200">
+          {method.sub}
+        </p>
+        <p className="mb-2 text-xs text-neutral-400 dark:text-neutral-500">
+          Setup cost: {method.setup}
+        </p>
+        <p className="text-xs leading-relaxed text-neutral-600 dark:text-neutral-400">
+          {method.desc}
+        </p>
+      </div>
+
+      <div className="space-y-2.5">
+        {METRICS.map((m) => (
+          <div key={m.key}>
+            <div className="mb-1 flex items-center justify-between text-xs">
+              <span className="text-neutral-600 dark:text-neutral-400">
+                {m.label}
+              </span>
+              <span className="text-neutral-500 tabular-nums dark:text-neutral-500">
+                {method[m.key]}%
+              </span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-neutral-100 dark:bg-neutral-800">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${m.color}`}
+                style={{ width: `${method[m.key]}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/components/eval-coverage-matrix.tsx
+++ b/app/components/eval-coverage-matrix.tsx
@@ -1,0 +1,110 @@
+'use client'
+import React from 'react'
+
+const FAILURE_MODES = [
+  'Verbosity bias',
+  'Position bias',
+  'Self-preference bias',
+  'Factual regression',
+  'Format / schema breakage',
+  'Metric drift from user outcomes',
+]
+
+const METHODS = [
+  {
+    name: 'Deterministic checks',
+    short: 'Det.',
+    covers: [false, false, false, false, true, false],
+  },
+  {
+    name: 'Reference-based metrics',
+    short: 'Ref.',
+    covers: [false, false, false, true, true, false],
+  },
+  {
+    name: 'Same-provider judge',
+    short: 'Same',
+    covers: [false, false, false, false, false, false],
+  },
+  {
+    name: 'Cross-provider judge',
+    short: 'Cross',
+    covers: [true, false, true, false, false, false],
+  },
+  {
+    name: 'Human eval set',
+    short: 'Human',
+    covers: [true, true, true, true, true, true],
+  },
+]
+
+export function EvalCoverageMatrix() {
+  return (
+    <div className="not-prose my-8 overflow-x-auto rounded-xl border border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <div className="p-5 pb-3">
+        <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+          Eval Method Coverage
+        </p>
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">
+          Which failure modes each evaluation approach can actually catch
+        </p>
+      </div>
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="border-t border-neutral-200 dark:border-neutral-800">
+            <th className="px-5 py-2.5 text-left font-medium text-neutral-500 dark:text-neutral-400">
+              Failure mode
+            </th>
+            {METHODS.map((m) => (
+              <th
+                key={m.name}
+                className="px-3 py-2.5 text-center font-medium text-neutral-500 dark:text-neutral-400"
+                title={m.name}
+              >
+                {m.short}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {FAILURE_MODES.map((mode, i) => (
+            <tr
+              key={mode}
+              className="border-t border-neutral-100 dark:border-neutral-800/50"
+            >
+              <td className="px-5 py-2 text-neutral-700 dark:text-neutral-300">
+                {mode}
+              </td>
+              {METHODS.map((m) => (
+                <td key={m.name} className="px-3 py-2 text-center">
+                  {m.covers[i] ? (
+                    <span className="text-green-500">✓</span>
+                  ) : m.name === 'Same-provider judge' ? (
+                    <span className="text-red-400 dark:text-red-500">✗</span>
+                  ) : (
+                    <span className="text-neutral-200 dark:text-neutral-700">
+                      ○
+                    </span>
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex flex-wrap gap-4 border-t border-neutral-100 px-5 py-3 dark:border-neutral-800">
+        {METHODS.map((m) => (
+          <span
+            key={m.name}
+            className="text-xs text-neutral-400 dark:text-neutral-600"
+          >
+            <span className="font-medium text-neutral-700 dark:text-neutral-300">
+              {m.short}
+            </span>{' '}
+            = {m.name}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/components/labeled-code.tsx
+++ b/app/components/labeled-code.tsx
@@ -1,0 +1,36 @@
+export function LabeledCode({
+  type = 'note',
+  label,
+}: {
+  type?: 'good' | 'bad' | 'note'
+  label: string
+}) {
+  const config = {
+    good: {
+      className:
+        'border-green-500/40 bg-green-500/5 text-green-600 dark:text-green-400',
+      icon: '✓',
+    },
+    bad: {
+      className:
+        'border-red-500/40 bg-red-500/5 text-red-600 dark:text-red-400',
+      icon: '✗',
+    },
+    note: {
+      className:
+        'border-blue-500/40 bg-blue-500/5 text-blue-600 dark:text-blue-400',
+      icon: '→',
+    },
+  }
+
+  const { className, icon } = config[type]
+
+  return (
+    <div
+      className={`mt-6 mb-1 flex items-center gap-2 rounded border px-3 py-1.5 text-xs font-medium ${className}`}
+    >
+      <span aria-hidden="true">{icon}</span>
+      <span>{label}</span>
+    </div>
+  )
+}

--- a/app/components/mdx.tsx
+++ b/app/components/mdx.tsx
@@ -7,6 +7,12 @@ import { VibeSimulator } from 'app/components/vibe-simulator'
 import { Callout } from 'app/components/callout'
 import { StatCallout } from 'app/components/stat-callout'
 import { LabeledCode } from 'app/components/labeled-code'
+import { ToolDescriptionGrader } from 'app/components/tool-description-grader'
+import { ToolScaleSimulator } from 'app/components/tool-scale-simulator'
+import { VerbosityBiasDemo } from 'app/components/verbosity-bias-demo'
+import { EvalCoverageMatrix } from 'app/components/eval-coverage-matrix'
+import { ConsistencyTradeoffExplorer } from 'app/components/consistency-tradeoff-explorer'
+import { BenchmarkBlindspots } from 'app/components/benchmark-blindspots'
 import { PostPreviewLink } from 'app/components/post-preview-link'
 import { LinkPreview } from 'app/components/link-preview'
 import { slugify } from 'app/blog/utils.shared'
@@ -123,6 +129,12 @@ const components = {
   GistCode,
   StatCallout,
   LabeledCode,
+  ToolDescriptionGrader,
+  ToolScaleSimulator,
+  VerbosityBiasDemo,
+  EvalCoverageMatrix,
+  ConsistencyTradeoffExplorer,
+  BenchmarkBlindspots,
 }
 
 export function CustomMDX(props) {

--- a/app/components/mdx.tsx
+++ b/app/components/mdx.tsx
@@ -5,31 +5,35 @@ import React from 'react'
 import { Code, GistCode } from 'app/components/code'
 import { VibeSimulator } from 'app/components/vibe-simulator'
 import { Callout } from 'app/components/callout'
+import { StatCallout } from 'app/components/stat-callout'
+import { LabeledCode } from 'app/components/labeled-code'
 import { PostPreviewLink } from 'app/components/post-preview-link'
 import { LinkPreview } from 'app/components/link-preview'
 import { slugify } from 'app/blog/utils.shared'
 import { getBlogPosts } from 'app/blog/utils'
 
-function Table({ data }) {
-  const headers = data.headers.map((header, index) => (
-    <th key={index}>{header}</th>
-  ))
-  const rows = data.rows.map((row, index) => (
-    <tr key={index}>
-      {row.map((cell, cellIndex) => (
-        <td key={cellIndex}>{cell}</td>
-      ))}
-    </tr>
-  ))
-
-  return (
-    <table>
-      <thead>
-        <tr>{headers}</tr>
-      </thead>
-      <tbody>{rows}</tbody>
-    </table>
-  )
+function Table({ data, children }) {
+  if (data) {
+    const headers = data.headers.map((header, index) => (
+      <th key={index}>{header}</th>
+    ))
+    const rows = data.rows.map((row, index) => (
+      <tr key={index}>
+        {row.map((cell, cellIndex) => (
+          <td key={cellIndex}>{cell}</td>
+        ))}
+      </tr>
+    ))
+    return (
+      <table>
+        <thead>
+          <tr>{headers}</tr>
+        </thead>
+        <tbody>{rows}</tbody>
+      </table>
+    )
+  }
+  return <table>{children}</table>
 }
 
 function CustomLink(props) {
@@ -117,6 +121,8 @@ const components = {
   VibeSimulator,
   Callout,
   GistCode,
+  StatCallout,
+  LabeledCode,
 }
 
 export function CustomMDX(props) {

--- a/app/components/stat-callout.tsx
+++ b/app/components/stat-callout.tsx
@@ -1,0 +1,38 @@
+export function StatCallout({
+  stat,
+  label,
+  source,
+  sourceUrl,
+}: {
+  stat: string
+  label: string
+  source?: string
+  sourceUrl?: string
+}) {
+  return (
+    <div className="my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-6 text-center dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="text-5xl font-bold tracking-tight text-neutral-900 dark:text-white">
+        {stat}
+      </p>
+      <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
+        {label}
+      </p>
+      {source && (
+        <p className="mt-2 text-xs text-neutral-400 dark:text-neutral-600">
+          {sourceUrl ? (
+            <a
+              href={sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2 hover:text-neutral-600 dark:hover:text-neutral-400"
+            >
+              {source}
+            </a>
+          ) : (
+            source
+          )}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/app/components/tool-description-grader.tsx
+++ b/app/components/tool-description-grader.tsx
@@ -1,0 +1,160 @@
+'use client'
+import React, { useState, useMemo } from 'react'
+
+interface Check {
+  id: string
+  label: string
+  hint: string
+  test: (s: string) => boolean
+  weight: number
+}
+
+const CHECKS: Check[] = [
+  {
+    id: 'length',
+    label: 'Adequate length',
+    hint: 'At least 50 characters — one-liners never carry enough signal',
+    test: (s) => s.trim().length >= 50,
+    weight: 10,
+  },
+  {
+    id: 'purpose',
+    label: 'States what it does or returns',
+    hint: 'Mention what the tool retrieves, creates, or produces',
+    test: (s) =>
+      /\b(returns?|fetches?|retrieves?|gets?|creates?|searches?|finds?|lists?|generates?|sends?|calculates?|extracts?|converts?)\b/i.test(
+        s,
+      ),
+    weight: 20,
+  },
+  {
+    id: 'when',
+    label: 'Explains when to use it',
+    hint: '"Use when...", "to get...", or a concrete use-case sentence',
+    test: (s) =>
+      /\b(use when|use this when|use for|when you (need|want|have)|to (get|find|create|retrieve|fetch|search)|for (getting|finding|searching|retrieving))\b/i.test(
+        s,
+      ),
+    weight: 20,
+  },
+  {
+    id: 'antipattern',
+    label: 'Anti-patterns listed',
+    hint: '"Do NOT use for X — use Y() instead"',
+    test: (s) =>
+      /\b(do not use|don'?t use|not for|avoid using|instead use|use .+ instead)\b/i.test(
+        s,
+      ),
+    weight: 30,
+  },
+  {
+    id: 'params',
+    label: 'Required inputs mentioned',
+    hint: 'Reference required parameters or context',
+    test: (s) =>
+      /\b(requires?|needs?|expects?|must (have|provide|pass|supply)|with a valid|provide (a|an|the)|pass (a|an|the))\b/i.test(
+        s,
+      ),
+    weight: 20,
+  },
+]
+
+function ScoreTag({ score }: { score: number }) {
+  if (score >= 80)
+    return (
+      <span className="font-medium text-green-600 dark:text-green-400">
+        Good
+      </span>
+    )
+  if (score >= 50)
+    return (
+      <span className="font-medium text-yellow-600 dark:text-yellow-400">
+        Needs work
+      </span>
+    )
+  return (
+    <span className="font-medium text-red-600 dark:text-red-400">
+      Likely causing errors
+    </span>
+  )
+}
+
+export function ToolDescriptionGrader() {
+  const [input, setInput] = useState('')
+
+  const results = useMemo(() => {
+    const trimmed = input.trim()
+    if (!trimmed) return null
+    const checks = CHECKS.map((c) => ({ ...c, passed: c.test(trimmed) }))
+    const score = checks.reduce((sum, c) => sum + (c.passed ? c.weight : 0), 0)
+    return { checks, score }
+  }, [input])
+
+  const barColor = results
+    ? results.score >= 80
+      ? 'bg-green-500'
+      : results.score >= 50
+        ? 'bg-yellow-500'
+        : 'bg-red-500'
+    : 'bg-neutral-300 dark:bg-neutral-600'
+
+  return (
+    <div className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+        Tool Description Grader
+      </p>
+      <p className="mb-4 text-xs text-neutral-500 dark:text-neutral-400">
+        Paste a tool description to see what signal the model actually reads
+      </p>
+      <textarea
+        className="w-full rounded-lg border border-neutral-200 bg-white p-3 font-mono text-xs text-neutral-900 placeholder-neutral-400 focus:border-neutral-400 focus:outline-none dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder-neutral-600"
+        rows={3}
+        placeholder="Gets data for a user."
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+      />
+      {results && (
+        <div className="mt-3 space-y-3">
+          <div className="flex items-center gap-3">
+            <div className="h-2 flex-1 overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-700">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${barColor}`}
+                style={{ width: `${results.score}%` }}
+              />
+            </div>
+            <div className="w-36 text-right text-xs text-neutral-600 dark:text-neutral-400">
+              {results.score}/100 &mdash; <ScoreTag score={results.score} />
+            </div>
+          </div>
+          <ul className="space-y-1.5">
+            {results.checks.map((c) => (
+              <li key={c.id} className="flex items-start gap-2 text-xs">
+                <span
+                  className={`mt-px shrink-0 font-mono ${c.passed ? 'text-green-500' : 'text-neutral-300 dark:text-neutral-600'}`}
+                >
+                  {c.passed ? '✓' : '○'}
+                </span>
+                <span>
+                  <span
+                    className={
+                      c.passed
+                        ? 'text-neutral-700 dark:text-neutral-300'
+                        : 'text-neutral-400 dark:text-neutral-600'
+                    }
+                  >
+                    {c.label}
+                  </span>
+                  {!c.passed && (
+                    <span className="ml-1 text-neutral-400 dark:text-neutral-500">
+                      &mdash; {c.hint}
+                    </span>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/components/tool-scale-simulator.tsx
+++ b/app/components/tool-scale-simulator.tsx
@@ -1,0 +1,130 @@
+'use client'
+import React, { useState } from 'react'
+
+const ZONES = [
+  {
+    max: 5,
+    label: 'Safe zone',
+    color: 'green' as const,
+    desc: 'Reliable selection. Model can distinguish all tools. Focus on description quality, not architecture.',
+  },
+  {
+    max: 12,
+    label: 'Caution',
+    color: 'yellow' as const,
+    desc: 'Occasional wrong selection for semantically similar tools. Audit descriptions and add anti-patterns.',
+  },
+  {
+    max: 20,
+    label: 'Danger zone',
+    color: 'orange' as const,
+    desc: 'Consistent confusion between overlapping tools. Phantom function calls appear. A retrieval layer is overdue.',
+  },
+  {
+    max: Infinity,
+    label: 'Overloaded',
+    color: 'red' as const,
+    desc: 'Flat-list injection is unsafe at this scale. registry.query(context, top_k=8) is required.',
+  },
+]
+
+type Color = (typeof ZONES)[number]['color']
+
+const colorMap: Record<
+  Color,
+  { bar: string; text: string; bg: string; border: string }
+> = {
+  green: {
+    bar: 'bg-green-500',
+    text: 'text-green-700 dark:text-green-400',
+    bg: 'bg-green-50 dark:bg-green-950/40',
+    border: 'border-green-200 dark:border-green-900',
+  },
+  yellow: {
+    bar: 'bg-yellow-500',
+    text: 'text-yellow-700 dark:text-yellow-400',
+    bg: 'bg-yellow-50 dark:bg-yellow-950/40',
+    border: 'border-yellow-200 dark:border-yellow-900',
+  },
+  orange: {
+    bar: 'bg-orange-500',
+    text: 'text-orange-700 dark:text-orange-400',
+    bg: 'bg-orange-50 dark:bg-orange-950/40',
+    border: 'border-orange-200 dark:border-orange-900',
+  },
+  red: {
+    bar: 'bg-red-500',
+    text: 'text-red-700 dark:text-red-400',
+    bg: 'bg-red-50 dark:bg-red-950/40',
+    border: 'border-red-200 dark:border-red-900',
+  },
+}
+
+function getAccuracy(n: number): number {
+  if (n <= 5) return 97
+  if (n <= 12) return Math.round(97 - (n - 5) * 4.5)
+  if (n <= 20) return Math.round(65 - (n - 12) * 2.5)
+  return Math.max(18, Math.round(45 - (n - 20) * 1.3))
+}
+
+export function ToolScaleSimulator() {
+  const [count, setCount] = useState(8)
+
+  const zone = ZONES.find((z) => count <= z.max)!
+  const accuracy = getAccuracy(count)
+  const c = colorMap[zone.color]
+
+  return (
+    <div className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+        Tool Count Simulator
+      </p>
+      <p className="mb-4 text-xs text-neutral-500 dark:text-neutral-400">
+        Drag to change registry size and see estimated selection accuracy
+      </p>
+
+      <div className="mb-4 flex items-center gap-4">
+        <input
+          type="range"
+          min={1}
+          max={40}
+          value={count}
+          onChange={(e) => setCount(Number(e.target.value))}
+          className="flex-1 accent-neutral-700 dark:accent-neutral-300"
+        />
+        <span className="w-16 text-right text-2xl font-bold text-neutral-900 tabular-nums dark:text-white">
+          {count}
+        </span>
+      </div>
+
+      <div className="mb-3 grid grid-cols-2 gap-2">
+        <div className="rounded-lg border border-neutral-200 bg-white p-3 dark:border-neutral-700 dark:bg-neutral-950">
+          <p className="mb-1 text-xs text-neutral-500 dark:text-neutral-400">
+            Est. selection accuracy
+          </p>
+          <p className="text-xl font-bold text-neutral-900 dark:text-white">
+            {accuracy}%
+          </p>
+          <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-neutral-100 dark:bg-neutral-800">
+            <div
+              className="h-full rounded-full bg-blue-500 transition-all duration-500"
+              style={{ width: `${accuracy}%` }}
+            />
+          </div>
+        </div>
+        <div className={`rounded-lg border p-3 ${c.bg} ${c.border}`}>
+          <p className="mb-1 text-xs text-neutral-500 dark:text-neutral-400">
+            Status
+          </p>
+          <p className={`text-xl font-bold ${c.text}`}>{zone.label}</p>
+        </div>
+      </div>
+
+      <div
+        className={`rounded-lg border p-3 text-xs ${c.bg} ${c.border} ${c.text}`}
+      >
+        {zone.desc}
+      </div>
+    </div>
+  )
+}

--- a/app/components/verbosity-bias-demo.tsx
+++ b/app/components/verbosity-bias-demo.tsx
@@ -1,0 +1,115 @@
+'use client'
+import React, { useState } from 'react'
+
+const SHORT = {
+  label: 'Concise answer',
+  words: 6,
+  text: 'Paris is the capital of France.',
+  score: 5.1,
+}
+
+const VERBOSE = {
+  label: 'Padded answer',
+  words: 63,
+  text: "That's a great question! Paris, which has been the capital of France since the late 10th century, is indeed the capital of France. It serves as the country's political, economic, and cultural center. The city, situated along the Seine river, has a rich history spanning over 2,000 years and is home to iconic landmarks. To summarize: Paris is the capital of France.",
+  score: 8.2,
+}
+
+type State = 'idle' | 'judging' | 'done'
+
+export function VerbosityBiasDemo() {
+  const [flipped, setFlipped] = useState(false)
+  const [state, setState] = useState<State>('idle')
+
+  const a = flipped ? VERBOSE : SHORT
+  const b = flipped ? SHORT : VERBOSE
+
+  function runJudge() {
+    setState('judging')
+    setTimeout(() => setState('done'), 1400)
+  }
+
+  function swap() {
+    setFlipped((f) => !f)
+    setState('idle')
+  }
+
+  return (
+    <div className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+        Verbosity + Position Bias Demo
+      </p>
+      <p className="mb-1 text-xs text-neutral-500 dark:text-neutral-400">
+        Both responses are factually correct. Run the judge to see which wins.
+      </p>
+      <p className="mb-4 text-xs text-neutral-400 italic dark:text-neutral-600">
+        Q: What is the capital of France?
+      </p>
+
+      <div className="mb-4 grid grid-cols-2 gap-3">
+        {[a, b].map((ans, i) => (
+          <div
+            key={i}
+            className="flex flex-col rounded-lg border border-neutral-200 bg-white p-3 dark:border-neutral-700 dark:bg-neutral-950"
+          >
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-xs font-medium text-neutral-500">
+                Response {i === 0 ? 'A' : 'B'}
+              </span>
+              <span className="text-xs text-neutral-400">{ans.words}w</span>
+            </div>
+            <p className="flex-1 text-xs leading-relaxed text-neutral-700 dark:text-neutral-300">
+              {ans.text}
+            </p>
+            {state === 'done' && (
+              <div className="mt-3 border-t border-neutral-100 pt-3 dark:border-neutral-800">
+                <div className="mb-1 flex items-center justify-between">
+                  <span className="text-xs text-neutral-400">Judge score</span>
+                  <span
+                    className={`text-sm font-bold tabular-nums ${ans.score > 7 ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'}`}
+                  >
+                    {ans.score}/10
+                  </span>
+                </div>
+                <div className="h-1.5 overflow-hidden rounded-full bg-neutral-100 dark:bg-neutral-800">
+                  <div
+                    className={`h-full rounded-full transition-all duration-700 ${ans.score > 7 ? 'bg-green-500' : 'bg-red-400'}`}
+                    style={{ width: `${ans.score * 10}%` }}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          onClick={runJudge}
+          disabled={state === 'judging'}
+          className="flex-1 rounded-lg bg-neutral-900 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-neutral-700 disabled:opacity-50 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-200"
+        >
+          {state === 'judging'
+            ? 'Judging…'
+            : state === 'done'
+              ? 'Re-run judge'
+              : 'Run gpt-4o judge'}
+        </button>
+        <button
+          onClick={swap}
+          className="rounded-lg border border-neutral-200 px-3 py-2 text-xs font-medium text-neutral-600 transition-colors hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-800"
+        >
+          Swap order
+        </button>
+      </div>
+
+      {state === 'done' && (
+        <p className="mt-3 text-xs text-neutral-500 dark:text-neutral-400">
+          {flipped
+            ? 'Verbose answer is now in position A and still wins. Longer always beats shorter. Earlier always beats later. Both biases confirmed.'
+            : 'Verbose answer wins despite identical facts. Now swap the order — position B next.'}
+        </p>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- New blog post: *The Tool Registry Is the Heart of Your Agent — Treat It That Way*
- Argues tool descriptions are the primary production failure surface for AI agents — not model choice, not orchestration
- Grounded in Cyclops development experience; cites 2025 paper (97.1% MCP description quality issues) and MCP-Zero paper
- Three-failure-mode taxonomy: incorrect selection, parameter hallucination, tool interference
- Contrarian claim: the description matters more than the implementation

## Test plan

- [ ] Verify post renders correctly at `/blog/tool-registry-agents`
- [ ] Check all external links resolve
- [ ] Confirm frontmatter tags display correctly
- [ ] Review on mobile