### PR TITLE
blog: Your Eval Suite Is Lying to You

### DIFF
--- a/app/blog/[slug]/blog-post-client.tsx
+++ b/app/blog/[slug]/blog-post-client.tsx
@@ -13,6 +13,8 @@ import { formatDate, slugify } from 'app/blog/utils.shared'
 import { Code, GistCode } from 'app/components/code'
 import { VibeSimulator } from 'app/components/vibe-simulator'
 import { Callout } from 'app/components/callout'
+import { StatCallout } from 'app/components/stat-callout'
+import { LabeledCode } from 'app/components/labeled-code'
 import { LinkPreview } from 'app/components/link-preview'
 import { PostPreviewLink } from 'app/components/post-preview-link'
 import type { BlogPost, Heading } from 'app/blog/utils.shared'
@@ -87,6 +89,31 @@ const baseTinaComponents: Record<string, any> = {
     content?: string
   }) => <Callout type={type}>{content}</Callout>,
   GistCode: ({ url }: { url: string }) => <GistCode url={url} />,
+  StatCallout: ({
+    stat,
+    label,
+    source,
+    sourceUrl,
+  }: {
+    stat: string
+    label: string
+    source?: string
+    sourceUrl?: string
+  }) => (
+    <StatCallout
+      stat={stat}
+      label={label}
+      source={source}
+      sourceUrl={sourceUrl}
+    />
+  ),
+  LabeledCode: ({
+    type,
+    label,
+  }: {
+    type?: 'good' | 'bad' | 'note'
+    label: string
+  }) => <LabeledCode type={type} label={label} />,
 }
 
 interface BlogPostClientProps {

--- a/app/blog/[slug]/blog-post-client.tsx
+++ b/app/blog/[slug]/blog-post-client.tsx
@@ -15,6 +15,12 @@ import { VibeSimulator } from 'app/components/vibe-simulator'
 import { Callout } from 'app/components/callout'
 import { StatCallout } from 'app/components/stat-callout'
 import { LabeledCode } from 'app/components/labeled-code'
+import { ToolDescriptionGrader } from 'app/components/tool-description-grader'
+import { ToolScaleSimulator } from 'app/components/tool-scale-simulator'
+import { VerbosityBiasDemo } from 'app/components/verbosity-bias-demo'
+import { EvalCoverageMatrix } from 'app/components/eval-coverage-matrix'
+import { ConsistencyTradeoffExplorer } from 'app/components/consistency-tradeoff-explorer'
+import { BenchmarkBlindspots } from 'app/components/benchmark-blindspots'
 import { LinkPreview } from 'app/components/link-preview'
 import { PostPreviewLink } from 'app/components/post-preview-link'
 import type { BlogPost, Heading } from 'app/blog/utils.shared'
@@ -114,6 +120,12 @@ const baseTinaComponents: Record<string, any> = {
     type?: 'good' | 'bad' | 'note'
     label: string
   }) => <LabeledCode type={type} label={label} />,
+  ToolDescriptionGrader: () => <ToolDescriptionGrader />,
+  ToolScaleSimulator: () => <ToolScaleSimulator />,
+  VerbosityBiasDemo: () => <VerbosityBiasDemo />,
+  EvalCoverageMatrix: () => <EvalCoverageMatrix />,
+  ConsistencyTradeoffExplorer: () => <ConsistencyTradeoffExplorer />,
+  BenchmarkBlindspots: () => <BenchmarkBlindspots />,
 }
 
 interface BlogPostClientProps {

--- a/app/blog/posts/eval-suite-lying.mdx
+++ b/app/blog/posts/eval-suite-lying.mdx
@@ -13,52 +13,93 @@ Three weeks after deploying a retrieval pipeline upgrade, our eval scores were u
 
 User satisfaction dropped.
 
-It took another two weeks to understand what happened. The new pipeline produced longer, more verbose answers. The LLM-as-a-judge we were using — GPT-4o evaluating GPT-4o outputs — has a documented preference for verbosity. It was rewarding length, not accuracy. Our "improvement" was the model learning to pad responses in exactly the way its own evaluator liked.
+It took another two weeks to understand what happened. The new pipeline produced longer, more verbose answers. The LLM-as-a-judge we were using — `gpt-4o` evaluating `gpt-4o` outputs — has a documented preference for verbosity. It was rewarding length, not accuracy. Our "improvement" was the model learning to pad responses in exactly the way its own evaluator liked.
 
-This is the trap. Not that evals are useless — they're essential. But a lot of teams have replaced no evals with the wrong evals and declared the problem solved.
+This is the trap. Not that evals are useless — they're essential. But a lot of teams have replaced no evals with the *wrong* evals and declared the problem solved.
 
-## The Bias Stack Nobody Warns You About
+## The bias stack nobody warns you about
 
-LLM-as-a-judge has at least four well-documented failure modes that compound each other. Verbosity bias: judges consistently rate longer outputs higher, independent of correctness. Position bias: the judge favors whichever response appears first in pairwise comparison. Self-preference bias — confirmed in a NeurIPS 2024 paper — shows models recognize and prefer outputs statistically similar to their own training distribution. And reference score anchoring, where a rubric with fixed example scores systematically skews the entire distribution toward those anchors.
+LLM-as-a-judge has at least four well-documented failure modes that compound each other:
 
-Running all four simultaneously, with the judge model and the generation model from the same provider family, compounds them. You get an eval suite that is highly sensitive to changes that make responses more GPT-like, and blind to changes that make them factually more accurate.
+| Bias | What it does |
+|------|-------------|
+| **Verbosity bias** | Judges consistently rate longer outputs higher, independent of correctness |
+| **Position bias** | The judge favors whichever response appears first in pairwise comparison |
+| **Self-preference** | Models recognize and prefer outputs similar to their own training distribution ([NeurIPS 2024](https://arxiv.org/abs/2404.13076)) |
+| **Anchoring** | A rubric with fixed example scores skews the entire distribution toward those anchors |
+
+Run all four simultaneously, with the judge model and the generation model from the same provider family, and they compound. You get an eval suite that is highly sensitive to changes that make responses more GPT-like, and blind to changes that make them factually more accurate.
 
 A research collaborator would call these confounds and control for them in the experimental design. In production, they quietly inflate your score while you demo the improvement to stakeholders.
 
-## Different Signal Types Fail Differently
+## Different signal types fail differently
 
 The shortest path to trustworthy evals isn't a better LLM judge. It's layering evaluation types so their failure modes don't overlap.
 
-Start with deterministic checks. These feel almost insultingly simple — does the response contain a citation? Is the JSON parseable? Does the answer fall within expected length bounds? — but they catch a surprising share of regressions with zero bias. If your pipeline produces structured output, write schema validation before you write any LLM judge prompts at all.
+**Start with deterministic checks.** These feel almost insultingly simple — does the response contain a citation? Is the JSON parseable? Does the answer fall within expected length bounds? They catch a surprising share of regressions with zero bias. If your pipeline produces structured output, write schema validation before you write any judge prompts at all.
 
-Add reference-based metrics where you have ground truth. Not ROUGE or BLEU — those were designed for machine translation and punish legitimate paraphrasing. Exact-match on key facts and named entities, drawn from a golden QA set, will catch factual regressions that no judge model reliably surfaces.
+**Add reference-based metrics where you have ground truth.** Not [ROUGE](https://aclanthology.org/W04-1013/) or BLEU — those were designed for machine translation and punish legitimate paraphrasing. Exact-match on key facts and named entities, drawn from a golden QA set, will catch factual regressions that no judge model reliably surfaces.
 
-Use LLM-as-judge only for genuinely subjective dimensions: tone, safety, coherence. When you do, use a cross-provider judge. If you're generating with Gemini 2.5 Flash, judge with Claude 3.5 Sonnet or a Mistral-family model. Cross-provider judging doesn't eliminate bias but it breaks the self-preference loop that makes homogenous evaluation so dangerous.
+**Use LLM-as-judge only for genuinely subjective dimensions:** tone, safety, coherence. When you do, use a cross-provider judge. If you're generating with [Gemini 2.5 Flash](https://deepmind.google/models/gemini/flash/), judge with [Claude 3.5 Sonnet](https://www.anthropic.com/claude/sonnet) or a Mistral-family model. Cross-provider judging doesn't eliminate bias but it breaks the self-preference loop that makes homogenous evaluation dangerous.
 
-Keep a human eval set — not a large one. Fifty examples, scored monthly by someone who actually uses the product. This is your calibration signal. If automated metrics move up but human scores don't, your evals have drifted from reality. This happens more often than most teams admit.
+**Keep a human eval set** — not a large one. Fifty examples, scored monthly by someone who actually uses the product. This is your calibration signal. If automated metrics move up but human scores don't, your evals have drifted from reality.
 
-## The Number That Refocused My Priorities
+A layered eval run looks something like this:
 
-Datadog's April 2026 State of AI Engineering report has a figure I keep returning to: 60% of LLM production failures are caused by capacity limits — rate limits and quota exhaustion. Not hallucinations. Not eval regressions. Rate limits.
+```python
+results = evaluator.run(
+    samples=test_set,
+    checks=[
+        SchemaValidator(),           # deterministic, zero bias
+        ExactMatchOnFacts(golden_qa), # reference-based
+        CrossProviderJudge(           # subjective only
+            generator="gemini-2.5-flash",
+            judge="claude-3-5-sonnet",
+            dimensions=["coherence", "safety"],
+        ),
+    ]
+)
+```
 
-Most teams I've talked to spend the bulk of their evaluation engineering on output quality — faithfulness, relevance, groundedness. Meanwhile their system is silently dropping 5% of requests, retrying with exponential backoff, and occasionally cascading that into a full agent workflow failure where every subsequent tool call operates on corrupted state.
+## The number that refocused my priorities
 
-Request success rate. P95 latency under load. Cost per successful query — not per token, per successful query, accounting for retries and fallbacks. Agent step completion rate across multi-turn traces. These are unglamorous metrics. They don't appear in eval framework demos. But an agent that silently fails 20% of its tool calls and continues as if it succeeded produces outputs that look coherent and are completely wrong. Your faithfulness score won't catch that.
+[Datadog's April 2026 State of AI Engineering report](https://www.datadoghq.com/state-of-ai-engineering/) has a figure I keep returning to: **60% of LLM production failures are caused by capacity limits — rate limits and quota exhaustion.** Not hallucinations. Not eval regressions. Rate limits.
 
-## The Instinct That Research Gave Me (and I Had to Unlearn)
+Most teams I've talked to spend the bulk of their evaluation engineering on output quality — faithfulness, relevance, groundedness. Meanwhile their system is silently dropping 5% of requests, retrying with exponential backoff, and occasionally cascading into a full agent workflow failure where every subsequent tool call operates on corrupted state.
+
+Request success rate. P95 latency under load. Cost per successful query (not per token — per successful query, accounting for retries and fallbacks). Agent step completion rate across multi-turn traces. These are unglamorous metrics. They don't appear in eval framework demos. But an agent that silently fails 20% of its tool calls and continues as if it succeeded produces outputs that look coherent and are completely wrong.
+
+<Callout type="warning" content="Your faithfulness score will not catch silent tool call failures. If your agent operates in a multi-step loop, instrument step completion rate separately from output quality. These are different signals requiring different interventions." />
+
+## The instinct that research gave me (and I had to unlearn)
 
 When I was working on diffusion models, variance in outputs was interesting. You'd study it, visualize the distribution, understand what drove it. High variance wasn't a bug — it was a property of the generative process worth analyzing.
 
 The first time I deployed an LLM eval harness with that mindset, the eval harness itself turned out to be non-deterministic. Same prompt, same model, different judge call, different score. I was tracking metrics to two decimal places that moved 0.05 between runs for reasons entirely unrelated to the system under test.
 
-The fix is straightforward once you see it: temperature=0 on all judge calls, seeded test set, always evaluate on a fixed sample. But the reflex to treat variance as signal rather than noise took time to correct. Research gives you the luxury of enough samples that variance averages out. Production eval runs typically give you 200 examples and a nightly cron job.
+The fix is straightforward once you see it:
 
-Cost is the other thing research doesn't prepare you for. Running GPT-4o as a judge across 1,000 examples isn't catastrophically expensive, but it's not free either — and it creates a perverse incentive to run evals rarely or on small samples, making them statistically meaningless for catching regressions. Gemini 2.5 Flash at $0.30/1M output tokens with sub-second latency changes this calculus. Small, fast judge models have closed most of the quality gap against their larger counterparts, and they make continuous eval pipelines — the kind that run on every PR, not just on release day — actually feasible.
+```python
+judge_response = client.chat.completions.create(
+    model="claude-3-5-sonnet-20241022",
+    temperature=0,          # critical: deterministic judge
+    seed=42,                # where supported
+    messages=[judge_prompt],
+)
+```
 
-## What "Good" Looks Like
+Set `temperature=0` on all judge calls, seed your test set, always evaluate on a fixed sample. The reflex to treat variance as signal rather than noise takes time to unlearn. Research gives you the luxury of enough samples that variance averages out. Production eval runs typically give you 200 examples and a nightly cron job.
 
-The teams I've seen get this right treat their eval suite like production code. Version controlled, with its own tests — yes, tests for your tests, which sounds absurd until you catch a bug in a judge prompt that's been silently scoring everything wrong for a sprint. A changelog. Ownership.
+Cost is the other thing research doesn't prepare you for. Running `gpt-4o` as a judge across 1,000 examples creates a perverse incentive to run evals rarely or on tiny samples, making them statistically meaningless for catching regressions. [Gemini 2.5 Flash](https://ai.google.dev/pricing) at $0.30/1M output tokens with sub-second latency changes this calculus significantly. Small, fast judge models have closed most of the quality gap against their larger counterparts, and they make continuous eval pipelines — the kind that run on every PR, not just on release day — actually feasible.
+
+Tools like [Braintrust](https://www.braintrust.dev/), [Langfuse](https://langfuse.com/), and [Weave](https://weave-docs.wandb.ai/) make it much easier to track this properly. The eval infrastructure is solved; the eval *strategy* usually isn't.
+
+## What "good" looks like
+
+The teams that get this right treat their eval suite like production code. Version controlled, with its own tests — yes, tests for your tests, which sounds absurd until you catch a bug in a judge prompt that's been silently scoring everything wrong for a sprint. A changelog. Ownership.
 
 And they audit their eval-to-production correlation quarterly. Do the examples where automated scores are high correspond to good user outcomes? If the answer is "we don't know," you don't have an eval suite. You have a false sense of control.
 
-The question worth sitting with: if your eval scores went up 10% this week, what would it actually take to convince you that was real? If your honest answer is "I'd check the dashboard and trust it," you should be worried. Because somewhere, a verbosity-biased GPT-4o judge is nodding along while your users quietly stop using the feature.
+> The question worth sitting with: if your eval scores went up 10% this week, what would it actually take to convince you that was real?
+
+If your honest answer is "I'd check the dashboard and trust it," you should be worried. Because somewhere, a verbosity-biased `gpt-4o` judge is nodding along while your users quietly stop using the feature.

--- a/app/blog/posts/eval-suite-lying.mdx
+++ b/app/blog/posts/eval-suite-lying.mdx
@@ -9,97 +9,113 @@ tags:
   - evaluation
 ---
 
-Three weeks after deploying a retrieval pipeline upgrade, our eval scores were up. Faithfulness: 0.84 → 0.91. Answer relevancy: 0.79 → 0.87. We shipped confidently.
+Three weeks after deploying a retrieval pipeline upgrade, our eval scores were up. Faithfulness: 0.84 to 0.91. Answer relevancy: 0.79 to 0.87. We shipped confidently.
 
 User satisfaction dropped.
 
 It took another two weeks to understand what happened. The new pipeline produced longer, more verbose answers. The LLM-as-a-judge we were using — `gpt-4o` evaluating `gpt-4o` outputs — has a documented preference for verbosity. It was rewarding length, not accuracy. Our "improvement" was the model learning to pad responses in exactly the way its own evaluator liked.
 
-This is the trap. Not that evals are useless — they're essential. But a lot of teams have replaced no evals with the *wrong* evals and declared the problem solved.
+This is the trap. Not that evals are useless — they are essential. But a lot of teams have replaced no evals with the *wrong* evals and declared the problem solved.
 
 ## The bias stack nobody warns you about
 
-LLM-as-a-judge has at least four well-documented failure modes that compound each other:
+LLM-as-a-judge has at least four well-documented failure modes that compound each other.
 
-| Bias | What it does |
-|------|-------------|
-| **Verbosity bias** | Judges consistently rate longer outputs higher, independent of correctness |
-| **Position bias** | The judge favors whichever response appears first in pairwise comparison |
-| **Self-preference** | Models recognize and prefer outputs similar to their own training distribution ([NeurIPS 2024](https://arxiv.org/abs/2404.13076)) |
-| **Anchoring** | A rubric with fixed example scores skews the entire distribution toward those anchors |
+### Verbosity bias
 
-Run all four simultaneously, with the judge model and the generation model from the same provider family, and they compound. You get an eval suite that is highly sensitive to changes that make responses more GPT-like, and blind to changes that make them factually more accurate.
+Judges consistently rate longer outputs higher, independent of correctness. This is the most common one. Add more sentences, get a better score — regardless of whether those sentences say anything useful.
 
-A research collaborator would call these confounds and control for them in the experimental design. In production, they quietly inflate your score while you demo the improvement to stakeholders.
+### Position bias
+
+The judge favors whichever response appears first in pairwise comparison. Run the same two responses in reversed order and you often get reversed scores. This makes A/B testing with LLM judges structurally unreliable.
+
+### Self-preference bias
+
+Models recognize and prefer outputs statistically similar to their own training distribution. This was confirmed in a [NeurIPS 2024 paper](https://arxiv.org/abs/2404.13076). When your judge model and your generation model come from the same provider family, you are not evaluating quality — you are measuring stylistic similarity to the judge's own outputs.
+
+### Reference score anchoring
+
+A rubric with fixed example scores systematically skews the entire distribution toward those anchors. If your rubric shows a "good" example scored 4/5, the judge will cluster scores around 4.
+
+Run all four simultaneously, with judge and generator from the same provider family, and you get an eval suite that is highly sensitive to changes that make responses more GPT-like, and blind to changes that make them factually more accurate. A research collaborator would call these confounds and control for them. In production, they quietly inflate your score while you demo the improvement to stakeholders.
 
 ## Different signal types fail differently
 
-The shortest path to trustworthy evals isn't a better LLM judge. It's layering evaluation types so their failure modes don't overlap.
+The shortest path to trustworthy evals is not a better LLM judge. It is layering evaluation types so their failure modes do not overlap.
 
 **Start with deterministic checks.** These feel almost insultingly simple — does the response contain a citation? Is the JSON parseable? Does the answer fall within expected length bounds? They catch a surprising share of regressions with zero bias. If your pipeline produces structured output, write schema validation before you write any judge prompts at all.
 
 **Add reference-based metrics where you have ground truth.** Not [ROUGE](https://aclanthology.org/W04-1013/) or BLEU — those were designed for machine translation and punish legitimate paraphrasing. Exact-match on key facts and named entities, drawn from a golden QA set, will catch factual regressions that no judge model reliably surfaces.
 
-**Use LLM-as-judge only for genuinely subjective dimensions:** tone, safety, coherence. When you do, use a cross-provider judge. If you're generating with [Gemini 2.5 Flash](https://deepmind.google/models/gemini/flash/), judge with [Claude 3.5 Sonnet](https://www.anthropic.com/claude/sonnet) or a Mistral-family model. Cross-provider judging doesn't eliminate bias but it breaks the self-preference loop that makes homogenous evaluation dangerous.
+**Use LLM-as-judge only for genuinely subjective dimensions:** tone, safety, coherence. When you do, use a cross-provider judge. If you are generating with [Gemini 2.5 Flash](https://deepmind.google/models/gemini/flash/), judge with [Claude 3.5 Sonnet](https://www.anthropic.com/claude/sonnet) or a Mistral-family model. Cross-provider judging does not eliminate bias but it breaks the self-preference loop that makes homogenous evaluation dangerous.
 
-**Keep a human eval set** — not a large one. Fifty examples, scored monthly by someone who actually uses the product. This is your calibration signal. If automated metrics move up but human scores don't, your evals have drifted from reality.
+**Keep a human eval set.** Not a large one — fifty examples, scored monthly by someone who actually uses the product. This is your calibration signal. If automated metrics move up but human scores do not, your evals have drifted from reality.
 
-A layered eval run looks something like this:
+A layered eval setup looks something like this:
 
 ```python
 results = evaluator.run(
     samples=test_set,
     checks=[
-        SchemaValidator(),           # deterministic, zero bias
-        ExactMatchOnFacts(golden_qa), # reference-based
-        CrossProviderJudge(           # subjective only
+        SchemaValidator(),              # deterministic, zero bias
+        ExactMatchOnFacts(golden_qa),   # reference-based
+        CrossProviderJudge(             # subjective dimensions only
             generator="gemini-2.5-flash",
             judge="claude-3-5-sonnet",
             dimensions=["coherence", "safety"],
         ),
-    ]
+    ],
 )
 ```
 
+Tools like [Braintrust](https://www.braintrust.dev/), [Langfuse](https://langfuse.com/), and [Weave](https://weave-docs.wandb.ai/) make it easier to track this properly. The eval infrastructure is largely solved. The eval *strategy* usually is not.
+
 ## The number that refocused my priorities
 
-[Datadog's April 2026 State of AI Engineering report](https://www.datadoghq.com/state-of-ai-engineering/) has a figure I keep returning to: **60% of LLM production failures are caused by capacity limits — rate limits and quota exhaustion.** Not hallucinations. Not eval regressions. Rate limits.
+<StatCallout
+  stat="60%"
+  label="of LLM production failures are caused by rate limits and quota exhaustion — not hallucinations, not eval regressions"
+  source="Datadog State of AI Engineering, April 2026"
+/>
 
-Most teams I've talked to spend the bulk of their evaluation engineering on output quality — faithfulness, relevance, groundedness. Meanwhile their system is silently dropping 5% of requests, retrying with exponential backoff, and occasionally cascading into a full agent workflow failure where every subsequent tool call operates on corrupted state.
+Most teams spend the bulk of their evaluation engineering on output quality: faithfulness, relevance, groundedness. Meanwhile their system is silently dropping 5% of requests, retrying with exponential backoff, and occasionally cascading into a full agent workflow failure where every subsequent tool call operates on corrupted state.
 
-Request success rate. P95 latency under load. Cost per successful query (not per token — per successful query, accounting for retries and fallbacks). Agent step completion rate across multi-turn traces. These are unglamorous metrics. They don't appear in eval framework demos. But an agent that silently fails 20% of its tool calls and continues as if it succeeded produces outputs that look coherent and are completely wrong.
+Request success rate. P95 latency under load. Cost per successful query — not per token, per *successful query*, accounting for retries and fallbacks. Agent step completion rate across multi-turn traces. These are unglamorous metrics. They do not appear in eval framework demos.
 
-<Callout type="warning" content="Your faithfulness score will not catch silent tool call failures. If your agent operates in a multi-step loop, instrument step completion rate separately from output quality. These are different signals requiring different interventions." />
+<Callout type="warning" content="An agent that silently fails 20% of its tool calls and continues as if it succeeded produces outputs that look coherent and are completely wrong. Your faithfulness score will not catch that. Instrument step completion rate separately from output quality." />
 
 ## The instinct that research gave me (and I had to unlearn)
 
-When I was working on diffusion models, variance in outputs was interesting. You'd study it, visualize the distribution, understand what drove it. High variance wasn't a bug — it was a property of the generative process worth analyzing.
+When I was working on diffusion models, variance in outputs was interesting. You would study it, visualize the distribution, understand what drove it. High variance was a property of the generative process worth analyzing.
 
 The first time I deployed an LLM eval harness with that mindset, the eval harness itself turned out to be non-deterministic. Same prompt, same model, different judge call, different score. I was tracking metrics to two decimal places that moved 0.05 between runs for reasons entirely unrelated to the system under test.
 
 The fix is straightforward once you see it:
 
+<LabeledCode type="bad" label="Non-deterministic judge: scores shift between identical runs" />
+
 ```python
-judge_response = client.chat.completions.create(
-    model="claude-3-5-sonnet-20241022",
-    temperature=0,          # critical: deterministic judge
-    seed=42,                # where supported
-    messages=[judge_prompt],
+response = judge.complete(prompt=judge_prompt)
+```
+
+<LabeledCode type="good" label="Deterministic judge: same input always produces same score" />
+
+```python
+response = judge.complete(
+    prompt=judge_prompt,
+    temperature=0,   # critical
+    seed=42,         # where supported
 )
 ```
 
-Set `temperature=0` on all judge calls, seed your test set, always evaluate on a fixed sample. The reflex to treat variance as signal rather than noise takes time to unlearn. Research gives you the luxury of enough samples that variance averages out. Production eval runs typically give you 200 examples and a nightly cron job.
+The reflex to treat variance as signal rather than noise takes time to unlearn. Research gives you the luxury of enough samples that variance averages out. Production eval runs typically give you 200 examples and a nightly cron job.
 
-Cost is the other thing research doesn't prepare you for. Running `gpt-4o` as a judge across 1,000 examples creates a perverse incentive to run evals rarely or on tiny samples, making them statistically meaningless for catching regressions. [Gemini 2.5 Flash](https://ai.google.dev/pricing) at $0.30/1M output tokens with sub-second latency changes this calculus significantly. Small, fast judge models have closed most of the quality gap against their larger counterparts, and they make continuous eval pipelines — the kind that run on every PR, not just on release day — actually feasible.
-
-Tools like [Braintrust](https://www.braintrust.dev/), [Langfuse](https://langfuse.com/), and [Weave](https://weave-docs.wandb.ai/) make it much easier to track this properly. The eval infrastructure is solved; the eval *strategy* usually isn't.
+Cost is the other thing research does not prepare you for. Running `gpt-4o` as a judge across 1,000 examples creates a perverse incentive to run evals rarely or on tiny samples, making them statistically meaningless. [Gemini 2.5 Flash](https://ai.google.dev/pricing) at $0.30/1M output tokens changes this calculus. Small, fast judge models have closed most of the quality gap, and they make continuous eval pipelines — the kind that run on every PR, not just on release day — actually feasible.
 
 ## What "good" looks like
 
-The teams that get this right treat their eval suite like production code. Version controlled, with its own tests — yes, tests for your tests, which sounds absurd until you catch a bug in a judge prompt that's been silently scoring everything wrong for a sprint. A changelog. Ownership.
+The teams that get this right treat their eval suite like production code. Version controlled. Own tests — yes, tests for your tests, which sounds absurd until you catch a bug in a judge prompt that has been silently scoring everything wrong for a sprint. A changelog. Ownership.
 
-And they audit their eval-to-production correlation quarterly. Do the examples where automated scores are high correspond to good user outcomes? If the answer is "we don't know," you don't have an eval suite. You have a false sense of control.
+They also audit their eval-to-production correlation quarterly. Do the examples where automated scores are high correspond to good user outcomes? If the answer is "we do not know," you do not have an eval suite. You have a false sense of control.
 
-> The question worth sitting with: if your eval scores went up 10% this week, what would it actually take to convince you that was real?
-
-If your honest answer is "I'd check the dashboard and trust it," you should be worried. Because somewhere, a verbosity-biased `gpt-4o` judge is nodding along while your users quietly stop using the feature.
+> If your eval scores went up 10% this week, what would it actually take to convince you that was real? If your honest answer is "I would check the dashboard and trust it" — somewhere, a verbosity-biased `gpt-4o` judge is nodding along while your users quietly stop using the feature.

--- a/app/blog/posts/eval-suite-lying.mdx
+++ b/app/blog/posts/eval-suite-lying.mdx
@@ -39,6 +39,8 @@ A rubric with fixed example scores systematically skews the entire distribution 
 
 Run all four simultaneously, with judge and generator from the same provider family, and you get an eval suite that is highly sensitive to changes that make responses more GPT-like, and blind to changes that make them factually more accurate. A research collaborator would call these confounds and control for them. In production, they quietly inflate your score while you demo the improvement to stakeholders.
 
+<VerbosityBiasDemo />
+
 ## Different signal types fail differently
 
 The shortest path to trustworthy evals is not a better LLM judge. It is layering evaluation types so their failure modes do not overlap.
@@ -67,6 +69,8 @@ results = evaluator.run(
     ],
 )
 ```
+
+<EvalCoverageMatrix />
 
 Tools like [Braintrust](https://www.braintrust.dev/), [Langfuse](https://langfuse.com/), and [Weave](https://weave-docs.wandb.ai/) make it easier to track this properly. The eval infrastructure is largely solved. The eval *strategy* usually is not.
 

--- a/app/blog/posts/eval-suite-lying.mdx
+++ b/app/blog/posts/eval-suite-lying.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Your Eval Suite Is Lying to You'
 publishedAt: '2026-04-22'
-summary: 'LLM-as-a-judge has become the default evaluation pattern — and it has systematic biases that make your metrics climb while your product quietly gets worse.'
+summary: 'LLM-as-a-judge has become the default evaluation pattern. It has systematic biases that make your metrics climb while your product quietly gets worse.'
 tags:
   - machine-learning
   - engineering
@@ -13,9 +13,9 @@ Three weeks after deploying a retrieval pipeline upgrade, our eval scores were u
 
 User satisfaction dropped.
 
-It took another two weeks to understand what happened. The new pipeline produced longer, more verbose answers. The LLM-as-a-judge we were using — `gpt-4o` evaluating `gpt-4o` outputs — has a documented preference for verbosity. It was rewarding length, not accuracy. Our "improvement" was the model learning to pad responses in exactly the way its own evaluator liked.
+It took another two weeks to understand what happened. The new pipeline produced longer, more verbose answers. The LLM-as-a-judge we were using (`gpt-4o` evaluating `gpt-4o` outputs) has a documented preference for verbosity. It was rewarding length, not accuracy. Our "improvement" was the model learning to pad responses in exactly the way its own evaluator liked.
 
-This is the trap. Not that evals are useless — they are essential. But a lot of teams have replaced no evals with the *wrong* evals and declared the problem solved.
+This is the trap. Not that evals are useless: they are essential. But a lot of teams have replaced no evals with the *wrong* evals and declared the problem solved.
 
 ## The bias stack nobody warns you about
 
@@ -23,7 +23,7 @@ LLM-as-a-judge has at least four well-documented failure modes that compound eac
 
 ### Verbosity bias
 
-Judges consistently rate longer outputs higher, independent of correctness. This is the most common one. Add more sentences, get a better score — regardless of whether those sentences say anything useful.
+Judges consistently rate longer outputs higher, independent of correctness. This is the most common one. Add more sentences, get a better score. Whether those sentences say anything useful is irrelevant to the judge.
 
 ### Position bias
 
@@ -31,7 +31,7 @@ The judge favors whichever response appears first in pairwise comparison. Run th
 
 ### Self-preference bias
 
-Models recognize and prefer outputs statistically similar to their own training distribution. This was confirmed in a [NeurIPS 2024 paper](https://arxiv.org/abs/2404.13076). When your judge model and your generation model come from the same provider family, you are not evaluating quality — you are measuring stylistic similarity to the judge's own outputs.
+Models recognize and prefer outputs statistically similar to their own training distribution. This was confirmed in a [NeurIPS 2024 paper](https://arxiv.org/abs/2404.13076). When your judge model and your generation model come from the same provider family, you are not evaluating quality. You are measuring stylistic similarity to the judge's own outputs.
 
 ### Reference score anchoring
 
@@ -43,13 +43,13 @@ Run all four simultaneously, with judge and generator from the same provider fam
 
 The shortest path to trustworthy evals is not a better LLM judge. It is layering evaluation types so their failure modes do not overlap.
 
-**Start with deterministic checks.** These feel almost insultingly simple — does the response contain a citation? Is the JSON parseable? Does the answer fall within expected length bounds? They catch a surprising share of regressions with zero bias. If your pipeline produces structured output, write schema validation before you write any judge prompts at all.
+**Start with deterministic checks.** These feel almost insultingly simple: does the response contain a citation? Is the JSON parseable? Does the answer fall within expected length bounds? They catch a surprising share of regressions with zero bias. If your pipeline produces structured output, write schema validation before you write any judge prompts at all.
 
-**Add reference-based metrics where you have ground truth.** Not [ROUGE](https://aclanthology.org/W04-1013/) or BLEU — those were designed for machine translation and punish legitimate paraphrasing. Exact-match on key facts and named entities, drawn from a golden QA set, will catch factual regressions that no judge model reliably surfaces.
+**Add reference-based metrics where you have ground truth.** Not [ROUGE](https://aclanthology.org/W04-1013/) or BLEU, which were designed for machine translation and punish legitimate paraphrasing. Exact-match on key facts and named entities, drawn from a golden QA set, will catch factual regressions that no judge model reliably surfaces.
 
 **Use LLM-as-judge only for genuinely subjective dimensions:** tone, safety, coherence. When you do, use a cross-provider judge. If you are generating with [Gemini 2.5 Flash](https://deepmind.google/models/gemini/flash/), judge with [Claude 3.5 Sonnet](https://www.anthropic.com/claude/sonnet) or a Mistral-family model. Cross-provider judging does not eliminate bias but it breaks the self-preference loop that makes homogenous evaluation dangerous.
 
-**Keep a human eval set.** Not a large one — fifty examples, scored monthly by someone who actually uses the product. This is your calibration signal. If automated metrics move up but human scores do not, your evals have drifted from reality.
+**Keep a human eval set.** Not a large one: fifty examples, scored monthly by someone who actually uses the product. This is your calibration signal. If automated metrics move up but human scores do not, your evals have drifted from reality.
 
 A layered eval setup looks something like this:
 
@@ -74,13 +74,13 @@ Tools like [Braintrust](https://www.braintrust.dev/), [Langfuse](https://langfus
 
 <StatCallout
   stat="60%"
-  label="of LLM production failures are caused by rate limits and quota exhaustion — not hallucinations, not eval regressions"
+  label="of LLM production failures are caused by rate limits and quota exhaustion, not hallucinations or eval regressions"
   source="Datadog State of AI Engineering, April 2026"
 />
 
 Most teams spend the bulk of their evaluation engineering on output quality: faithfulness, relevance, groundedness. Meanwhile their system is silently dropping 5% of requests, retrying with exponential backoff, and occasionally cascading into a full agent workflow failure where every subsequent tool call operates on corrupted state.
 
-Request success rate. P95 latency under load. Cost per successful query — not per token, per *successful query*, accounting for retries and fallbacks. Agent step completion rate across multi-turn traces. These are unglamorous metrics. They do not appear in eval framework demos.
+Request success rate. P95 latency under load. Cost per successful query (not per raw token, counting retries and fallbacks). Agent step completion rate across multi-turn traces. These are unglamorous metrics. They do not appear in eval framework demos.
 
 <Callout type="warning" content="An agent that silently fails 20% of its tool calls and continues as if it succeeded produces outputs that look coherent and are completely wrong. Your faithfulness score will not catch that. Instrument step completion rate separately from output quality." />
 
@@ -110,12 +110,12 @@ response = judge.complete(
 
 The reflex to treat variance as signal rather than noise takes time to unlearn. Research gives you the luxury of enough samples that variance averages out. Production eval runs typically give you 200 examples and a nightly cron job.
 
-Cost is the other thing research does not prepare you for. Running `gpt-4o` as a judge across 1,000 examples creates a perverse incentive to run evals rarely or on tiny samples, making them statistically meaningless. [Gemini 2.5 Flash](https://ai.google.dev/pricing) at $0.30/1M output tokens changes this calculus. Small, fast judge models have closed most of the quality gap, and they make continuous eval pipelines — the kind that run on every PR, not just on release day — actually feasible.
+Cost is the other thing research does not prepare you for. Running `gpt-4o` as a judge across 1,000 examples creates a perverse incentive to run evals rarely or on tiny samples, making them statistically meaningless. [Gemini 2.5 Flash](https://ai.google.dev/pricing) at $0.30/1M output tokens changes this calculus. Small, fast judge models have closed most of the quality gap, and they make continuous eval pipelines (the kind that run on every PR, not just on release day) actually feasible.
 
 ## What "good" looks like
 
-The teams that get this right treat their eval suite like production code. Version controlled. Own tests — yes, tests for your tests, which sounds absurd until you catch a bug in a judge prompt that has been silently scoring everything wrong for a sprint. A changelog. Ownership.
+The teams that get this right treat their eval suite like production code. Version controlled. Own tests. Yes, tests for your tests, which sounds absurd until you catch a bug in a judge prompt that has been silently scoring everything wrong for a sprint. A changelog. Ownership.
 
 They also audit their eval-to-production correlation quarterly. Do the examples where automated scores are high correspond to good user outcomes? If the answer is "we do not know," you do not have an eval suite. You have a false sense of control.
 
-> If your eval scores went up 10% this week, what would it actually take to convince you that was real? If your honest answer is "I would check the dashboard and trust it" — somewhere, a verbosity-biased `gpt-4o` judge is nodding along while your users quietly stop using the feature.
+> If your eval scores went up 10% this week, what would it actually take to convince you that was real? If your honest answer is "I would check the dashboard and trust it," somewhere a verbosity-biased `gpt-4o` judge is nodding along while your users quietly stop using the feature.

--- a/app/blog/posts/eval-suite-lying.mdx
+++ b/app/blog/posts/eval-suite-lying.mdx
@@ -1,0 +1,64 @@
+---
+title: 'Your Eval Suite Is Lying to You'
+publishedAt: '2026-04-22'
+summary: 'LLM-as-a-judge has become the default evaluation pattern — and it has systematic biases that make your metrics climb while your product quietly gets worse.'
+tags:
+  - machine-learning
+  - engineering
+  - llm
+  - evaluation
+---
+
+Three weeks after deploying a retrieval pipeline upgrade, our eval scores were up. Faithfulness: 0.84 → 0.91. Answer relevancy: 0.79 → 0.87. We shipped confidently.
+
+User satisfaction dropped.
+
+It took another two weeks to understand what happened. The new pipeline produced longer, more verbose answers. The LLM-as-a-judge we were using — GPT-4o evaluating GPT-4o outputs — has a documented preference for verbosity. It was rewarding length, not accuracy. Our "improvement" was the model learning to pad responses in exactly the way its own evaluator liked.
+
+This is the trap. Not that evals are useless — they're essential. But a lot of teams have replaced no evals with the wrong evals and declared the problem solved.
+
+## The Bias Stack Nobody Warns You About
+
+LLM-as-a-judge has at least four well-documented failure modes that compound each other. Verbosity bias: judges consistently rate longer outputs higher, independent of correctness. Position bias: the judge favors whichever response appears first in pairwise comparison. Self-preference bias — confirmed in a NeurIPS 2024 paper — shows models recognize and prefer outputs statistically similar to their own training distribution. And reference score anchoring, where a rubric with fixed example scores systematically skews the entire distribution toward those anchors.
+
+Running all four simultaneously, with the judge model and the generation model from the same provider family, compounds them. You get an eval suite that is highly sensitive to changes that make responses more GPT-like, and blind to changes that make them factually more accurate.
+
+A research collaborator would call these confounds and control for them in the experimental design. In production, they quietly inflate your score while you demo the improvement to stakeholders.
+
+## Different Signal Types Fail Differently
+
+The shortest path to trustworthy evals isn't a better LLM judge. It's layering evaluation types so their failure modes don't overlap.
+
+Start with deterministic checks. These feel almost insultingly simple — does the response contain a citation? Is the JSON parseable? Does the answer fall within expected length bounds? — but they catch a surprising share of regressions with zero bias. If your pipeline produces structured output, write schema validation before you write any LLM judge prompts at all.
+
+Add reference-based metrics where you have ground truth. Not ROUGE or BLEU — those were designed for machine translation and punish legitimate paraphrasing. Exact-match on key facts and named entities, drawn from a golden QA set, will catch factual regressions that no judge model reliably surfaces.
+
+Use LLM-as-judge only for genuinely subjective dimensions: tone, safety, coherence. When you do, use a cross-provider judge. If you're generating with Gemini 2.5 Flash, judge with Claude 3.5 Sonnet or a Mistral-family model. Cross-provider judging doesn't eliminate bias but it breaks the self-preference loop that makes homogenous evaluation so dangerous.
+
+Keep a human eval set — not a large one. Fifty examples, scored monthly by someone who actually uses the product. This is your calibration signal. If automated metrics move up but human scores don't, your evals have drifted from reality. This happens more often than most teams admit.
+
+## The Number That Refocused My Priorities
+
+Datadog's April 2026 State of AI Engineering report has a figure I keep returning to: 60% of LLM production failures are caused by capacity limits — rate limits and quota exhaustion. Not hallucinations. Not eval regressions. Rate limits.
+
+Most teams I've talked to spend the bulk of their evaluation engineering on output quality — faithfulness, relevance, groundedness. Meanwhile their system is silently dropping 5% of requests, retrying with exponential backoff, and occasionally cascading that into a full agent workflow failure where every subsequent tool call operates on corrupted state.
+
+Request success rate. P95 latency under load. Cost per successful query — not per token, per successful query, accounting for retries and fallbacks. Agent step completion rate across multi-turn traces. These are unglamorous metrics. They don't appear in eval framework demos. But an agent that silently fails 20% of its tool calls and continues as if it succeeded produces outputs that look coherent and are completely wrong. Your faithfulness score won't catch that.
+
+## The Instinct That Research Gave Me (and I Had to Unlearn)
+
+When I was working on diffusion models, variance in outputs was interesting. You'd study it, visualize the distribution, understand what drove it. High variance wasn't a bug — it was a property of the generative process worth analyzing.
+
+The first time I deployed an LLM eval harness with that mindset, the eval harness itself turned out to be non-deterministic. Same prompt, same model, different judge call, different score. I was tracking metrics to two decimal places that moved 0.05 between runs for reasons entirely unrelated to the system under test.
+
+The fix is straightforward once you see it: temperature=0 on all judge calls, seeded test set, always evaluate on a fixed sample. But the reflex to treat variance as signal rather than noise took time to correct. Research gives you the luxury of enough samples that variance averages out. Production eval runs typically give you 200 examples and a nightly cron job.
+
+Cost is the other thing research doesn't prepare you for. Running GPT-4o as a judge across 1,000 examples isn't catastrophically expensive, but it's not free either — and it creates a perverse incentive to run evals rarely or on small samples, making them statistically meaningless for catching regressions. Gemini 2.5 Flash at $0.30/1M output tokens with sub-second latency changes this calculus. Small, fast judge models have closed most of the quality gap against their larger counterparts, and they make continuous eval pipelines — the kind that run on every PR, not just on release day — actually feasible.
+
+## What "Good" Looks Like
+
+The teams I've seen get this right treat their eval suite like production code. Version controlled, with its own tests — yes, tests for your tests, which sounds absurd until you catch a bug in a judge prompt that's been silently scoring everything wrong for a sprint. A changelog. Ownership.
+
+And they audit their eval-to-production correlation quarterly. Do the examples where automated scores are high correspond to good user outcomes? If the answer is "we don't know," you don't have an eval suite. You have a false sense of control.
+
+The question worth sitting with: if your eval scores went up 10% this week, what would it actually take to convince you that was real? If your honest answer is "I'd check the dashboard and trust it," you should be worried. Because somewhere, a verbosity-biased GPT-4o judge is nodding along while your users quietly stop using the feature.

--- a/app/components/benchmark-blindspots.tsx
+++ b/app/components/benchmark-blindspots.tsx
@@ -1,0 +1,133 @@
+'use client'
+import React from 'react'
+
+const SCENARIOS = [
+  {
+    scenario: 'Single subject, clean reference images',
+    note: 'The standard benchmark setup',
+    dinoI: true,
+    clipT: true,
+    dreamBench: true,
+    realWorld: false,
+  },
+  {
+    scenario: 'Multi-subject scene (3+ characters)',
+    note: 'Common production use case',
+    dinoI: false,
+    clipT: false,
+    dreamBench: false,
+    realWorld: true,
+  },
+  {
+    scenario: 'Subject in complex or novel background',
+    note: '',
+    dinoI: false,
+    clipT: true,
+    dreamBench: true,
+    realWorld: true,
+  },
+  {
+    scenario: 'Consistent character across a sequence',
+    note: 'Story, comic strip, product shoot',
+    dinoI: false,
+    clipT: false,
+    dreamBench: false,
+    realWorld: true,
+  },
+  {
+    scenario: 'Zero-shot generation (no fine-tuning)',
+    note: 'Hard constraint in many production pipelines',
+    dinoI: false,
+    clipT: false,
+    dreamBench: false,
+    realWorld: true,
+  },
+  {
+    scenario: 'Generated images as reference inputs',
+    note: 'Reference is itself slightly inconsistent',
+    dinoI: false,
+    clipT: false,
+    dreamBench: false,
+    realWorld: true,
+  },
+]
+
+function Cell({
+  covered,
+  productionCritical,
+}: {
+  covered: boolean
+  productionCritical: boolean
+}) {
+  if (covered)
+    return <span className="text-green-500 dark:text-green-400">✓</span>
+  if (productionCritical)
+    return <span className="font-bold text-red-500 dark:text-red-400">✗</span>
+  return <span className="text-neutral-200 dark:text-neutral-700">○</span>
+}
+
+export function BenchmarkBlindspots() {
+  return (
+    <div className="not-prose my-8 overflow-x-auto rounded-xl border border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <div className="p-5 pb-3">
+        <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+          Benchmark Coverage vs Real Scenarios
+        </p>
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">
+          Standard benchmarks cover the easy cases. Production breaks on the
+          rest.
+        </p>
+      </div>
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="border-t border-neutral-200 dark:border-neutral-800">
+            <th className="px-5 py-2.5 text-left font-medium text-neutral-500 dark:text-neutral-400">
+              Scenario
+            </th>
+            <th className="px-3 py-2.5 text-center font-medium text-neutral-500 dark:text-neutral-400">
+              DINO-I
+            </th>
+            <th className="px-3 py-2.5 text-center font-medium text-neutral-500 dark:text-neutral-400">
+              CLIP-T
+            </th>
+            <th className="px-3 py-2.5 text-center font-medium text-neutral-500 dark:text-neutral-400">
+              DreamBench
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {SCENARIOS.map((s) => (
+            <tr
+              key={s.scenario}
+              className="border-t border-neutral-100 dark:border-neutral-800/50"
+            >
+              <td className="px-5 py-2">
+                <span className="text-neutral-700 dark:text-neutral-300">
+                  {s.scenario}
+                </span>
+                {s.note && (
+                  <span className="ml-1.5 text-neutral-400 dark:text-neutral-600">
+                    ({s.note})
+                  </span>
+                )}
+              </td>
+              <td className="px-3 py-2 text-center">
+                <Cell covered={s.dinoI} productionCritical={s.realWorld} />
+              </td>
+              <td className="px-3 py-2 text-center">
+                <Cell covered={s.clipT} productionCritical={s.realWorld} />
+              </td>
+              <td className="px-3 py-2 text-center">
+                <Cell covered={s.dreamBench} productionCritical={s.realWorld} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="border-t border-neutral-100 px-5 py-3 text-xs text-neutral-400 dark:border-neutral-800 dark:text-neutral-600">
+        ✓ evaluated &nbsp;&nbsp; ✗ missing (production-critical) &nbsp;&nbsp; ○
+        not applicable
+      </p>
+    </div>
+  )
+}

--- a/app/components/consistency-tradeoff-explorer.tsx
+++ b/app/components/consistency-tradeoff-explorer.tsx
@@ -1,0 +1,112 @@
+'use client'
+import React, { useState } from 'react'
+
+const METHODS = [
+  {
+    label: 'Full fine-tuning',
+    sub: 'DreamBooth / LoRA per subject',
+    setup: 'Minutes to hours per subject',
+    fidelity: 95,
+    composability: 15,
+    flexibility: 5,
+    desc: 'Highest DINO-I scores. Strong texture reproduction. Each new subject needs its own fine-tune. LoRA fusion breaks down at 3+ subjects.',
+  },
+  {
+    label: 'Adapter-based',
+    sub: 'IP-Adapter-Plus style',
+    setup: 'Seconds at inference time',
+    fidelity: 72,
+    composability: 45,
+    flexibility: 60,
+    desc: 'Fast and flexible. Subject stays visually consistent at a glance. Complex prompt + subject compositions break. Text alignment degrades under load.',
+  },
+  {
+    label: 'Training-free',
+    sub: 'Masked cross-image attention',
+    setup: 'Zero — reference images at inference',
+    fidelity: 58,
+    composability: 80,
+    flexibility: 95,
+    desc: 'Zero-shot, any subject count, zero setup cost. Lower DINO-I. Attention leakage appears at 3+ subjects without masking. Benchmarks penalize this; users in practice often prefer it.',
+  },
+]
+
+const METRICS = [
+  {
+    key: 'fidelity',
+    label: 'Texture fidelity (what DINO-I measures)',
+    color: 'bg-blue-500',
+  },
+  {
+    key: 'composability',
+    label: 'Multi-subject composability',
+    color: 'bg-purple-500',
+  },
+  { key: 'flexibility', label: 'Zero-shot flexibility', color: 'bg-green-500' },
+] as const
+
+export function ConsistencyTradeoffExplorer() {
+  const [sel, setSel] = useState(0)
+  const method = METHODS[sel]
+
+  return (
+    <div className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+        Consistency Method Tradeoffs
+      </p>
+      <p className="mb-4 text-xs text-neutral-500 dark:text-neutral-400">
+        Each approach optimizes for a different axis. DINO-I only measures the
+        first one.
+      </p>
+
+      <div className="mb-4 flex gap-1.5">
+        {METHODS.map((m, i) => (
+          <button
+            key={m.label}
+            onClick={() => setSel(i)}
+            className={`flex-1 rounded-lg px-2 py-2 text-xs font-medium transition-colors ${
+              sel === i
+                ? 'bg-neutral-900 text-white dark:bg-white dark:text-neutral-900'
+                : 'border border-neutral-200 text-neutral-600 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-800'
+            }`}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mb-4 rounded-lg border border-neutral-200 bg-white p-3 dark:border-neutral-700 dark:bg-neutral-950">
+        <p className="mb-0.5 text-xs font-medium text-neutral-700 dark:text-neutral-200">
+          {method.sub}
+        </p>
+        <p className="mb-2 text-xs text-neutral-400 dark:text-neutral-500">
+          Setup cost: {method.setup}
+        </p>
+        <p className="text-xs leading-relaxed text-neutral-600 dark:text-neutral-400">
+          {method.desc}
+        </p>
+      </div>
+
+      <div className="space-y-2.5">
+        {METRICS.map((m) => (
+          <div key={m.key}>
+            <div className="mb-1 flex items-center justify-between text-xs">
+              <span className="text-neutral-600 dark:text-neutral-400">
+                {m.label}
+              </span>
+              <span className="text-neutral-500 tabular-nums dark:text-neutral-500">
+                {method[m.key]}%
+              </span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-neutral-100 dark:bg-neutral-800">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${m.color}`}
+                style={{ width: `${method[m.key]}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/components/eval-coverage-matrix.tsx
+++ b/app/components/eval-coverage-matrix.tsx
@@ -1,0 +1,110 @@
+'use client'
+import React from 'react'
+
+const FAILURE_MODES = [
+  'Verbosity bias',
+  'Position bias',
+  'Self-preference bias',
+  'Factual regression',
+  'Format / schema breakage',
+  'Metric drift from user outcomes',
+]
+
+const METHODS = [
+  {
+    name: 'Deterministic checks',
+    short: 'Det.',
+    covers: [false, false, false, false, true, false],
+  },
+  {
+    name: 'Reference-based metrics',
+    short: 'Ref.',
+    covers: [false, false, false, true, true, false],
+  },
+  {
+    name: 'Same-provider judge',
+    short: 'Same',
+    covers: [false, false, false, false, false, false],
+  },
+  {
+    name: 'Cross-provider judge',
+    short: 'Cross',
+    covers: [true, false, true, false, false, false],
+  },
+  {
+    name: 'Human eval set',
+    short: 'Human',
+    covers: [true, true, true, true, true, true],
+  },
+]
+
+export function EvalCoverageMatrix() {
+  return (
+    <div className="not-prose my-8 overflow-x-auto rounded-xl border border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <div className="p-5 pb-3">
+        <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+          Eval Method Coverage
+        </p>
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">
+          Which failure modes each evaluation approach can actually catch
+        </p>
+      </div>
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="border-t border-neutral-200 dark:border-neutral-800">
+            <th className="px-5 py-2.5 text-left font-medium text-neutral-500 dark:text-neutral-400">
+              Failure mode
+            </th>
+            {METHODS.map((m) => (
+              <th
+                key={m.name}
+                className="px-3 py-2.5 text-center font-medium text-neutral-500 dark:text-neutral-400"
+                title={m.name}
+              >
+                {m.short}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {FAILURE_MODES.map((mode, i) => (
+            <tr
+              key={mode}
+              className="border-t border-neutral-100 dark:border-neutral-800/50"
+            >
+              <td className="px-5 py-2 text-neutral-700 dark:text-neutral-300">
+                {mode}
+              </td>
+              {METHODS.map((m) => (
+                <td key={m.name} className="px-3 py-2 text-center">
+                  {m.covers[i] ? (
+                    <span className="text-green-500">✓</span>
+                  ) : m.name === 'Same-provider judge' ? (
+                    <span className="text-red-400 dark:text-red-500">✗</span>
+                  ) : (
+                    <span className="text-neutral-200 dark:text-neutral-700">
+                      ○
+                    </span>
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex flex-wrap gap-4 border-t border-neutral-100 px-5 py-3 dark:border-neutral-800">
+        {METHODS.map((m) => (
+          <span
+            key={m.name}
+            className="text-xs text-neutral-400 dark:text-neutral-600"
+          >
+            <span className="font-medium text-neutral-700 dark:text-neutral-300">
+              {m.short}
+            </span>{' '}
+            = {m.name}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/components/labeled-code.tsx
+++ b/app/components/labeled-code.tsx
@@ -1,0 +1,36 @@
+export function LabeledCode({
+  type = 'note',
+  label,
+}: {
+  type?: 'good' | 'bad' | 'note'
+  label: string
+}) {
+  const config = {
+    good: {
+      className:
+        'border-green-500/40 bg-green-500/5 text-green-600 dark:text-green-400',
+      icon: '✓',
+    },
+    bad: {
+      className:
+        'border-red-500/40 bg-red-500/5 text-red-600 dark:text-red-400',
+      icon: '✗',
+    },
+    note: {
+      className:
+        'border-blue-500/40 bg-blue-500/5 text-blue-600 dark:text-blue-400',
+      icon: '→',
+    },
+  }
+
+  const { className, icon } = config[type]
+
+  return (
+    <div
+      className={`mt-6 mb-1 flex items-center gap-2 rounded border px-3 py-1.5 text-xs font-medium ${className}`}
+    >
+      <span aria-hidden="true">{icon}</span>
+      <span>{label}</span>
+    </div>
+  )
+}

--- a/app/components/mdx.tsx
+++ b/app/components/mdx.tsx
@@ -7,6 +7,12 @@ import { VibeSimulator } from 'app/components/vibe-simulator'
 import { Callout } from 'app/components/callout'
 import { StatCallout } from 'app/components/stat-callout'
 import { LabeledCode } from 'app/components/labeled-code'
+import { ToolDescriptionGrader } from 'app/components/tool-description-grader'
+import { ToolScaleSimulator } from 'app/components/tool-scale-simulator'
+import { VerbosityBiasDemo } from 'app/components/verbosity-bias-demo'
+import { EvalCoverageMatrix } from 'app/components/eval-coverage-matrix'
+import { ConsistencyTradeoffExplorer } from 'app/components/consistency-tradeoff-explorer'
+import { BenchmarkBlindspots } from 'app/components/benchmark-blindspots'
 import { PostPreviewLink } from 'app/components/post-preview-link'
 import { LinkPreview } from 'app/components/link-preview'
 import { slugify } from 'app/blog/utils.shared'
@@ -123,6 +129,12 @@ const components = {
   GistCode,
   StatCallout,
   LabeledCode,
+  ToolDescriptionGrader,
+  ToolScaleSimulator,
+  VerbosityBiasDemo,
+  EvalCoverageMatrix,
+  ConsistencyTradeoffExplorer,
+  BenchmarkBlindspots,
 }
 
 export function CustomMDX(props) {

--- a/app/components/mdx.tsx
+++ b/app/components/mdx.tsx
@@ -5,31 +5,35 @@ import React from 'react'
 import { Code, GistCode } from 'app/components/code'
 import { VibeSimulator } from 'app/components/vibe-simulator'
 import { Callout } from 'app/components/callout'
+import { StatCallout } from 'app/components/stat-callout'
+import { LabeledCode } from 'app/components/labeled-code'
 import { PostPreviewLink } from 'app/components/post-preview-link'
 import { LinkPreview } from 'app/components/link-preview'
 import { slugify } from 'app/blog/utils.shared'
 import { getBlogPosts } from 'app/blog/utils'
 
-function Table({ data }) {
-  const headers = data.headers.map((header, index) => (
-    <th key={index}>{header}</th>
-  ))
-  const rows = data.rows.map((row, index) => (
-    <tr key={index}>
-      {row.map((cell, cellIndex) => (
-        <td key={cellIndex}>{cell}</td>
-      ))}
-    </tr>
-  ))
-
-  return (
-    <table>
-      <thead>
-        <tr>{headers}</tr>
-      </thead>
-      <tbody>{rows}</tbody>
-    </table>
-  )
+function Table({ data, children }) {
+  if (data) {
+    const headers = data.headers.map((header, index) => (
+      <th key={index}>{header}</th>
+    ))
+    const rows = data.rows.map((row, index) => (
+      <tr key={index}>
+        {row.map((cell, cellIndex) => (
+          <td key={cellIndex}>{cell}</td>
+        ))}
+      </tr>
+    ))
+    return (
+      <table>
+        <thead>
+          <tr>{headers}</tr>
+        </thead>
+        <tbody>{rows}</tbody>
+      </table>
+    )
+  }
+  return <table>{children}</table>
 }
 
 function CustomLink(props) {
@@ -117,6 +121,8 @@ const components = {
   VibeSimulator,
   Callout,
   GistCode,
+  StatCallout,
+  LabeledCode,
 }
 
 export function CustomMDX(props) {

--- a/app/components/stat-callout.tsx
+++ b/app/components/stat-callout.tsx
@@ -1,0 +1,38 @@
+export function StatCallout({
+  stat,
+  label,
+  source,
+  sourceUrl,
+}: {
+  stat: string
+  label: string
+  source?: string
+  sourceUrl?: string
+}) {
+  return (
+    <div className="my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-6 text-center dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="text-5xl font-bold tracking-tight text-neutral-900 dark:text-white">
+        {stat}
+      </p>
+      <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
+        {label}
+      </p>
+      {source && (
+        <p className="mt-2 text-xs text-neutral-400 dark:text-neutral-600">
+          {sourceUrl ? (
+            <a
+              href={sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2 hover:text-neutral-600 dark:hover:text-neutral-400"
+            >
+              {source}
+            </a>
+          ) : (
+            source
+          )}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/app/components/tool-description-grader.tsx
+++ b/app/components/tool-description-grader.tsx
@@ -1,0 +1,160 @@
+'use client'
+import React, { useState, useMemo } from 'react'
+
+interface Check {
+  id: string
+  label: string
+  hint: string
+  test: (s: string) => boolean
+  weight: number
+}
+
+const CHECKS: Check[] = [
+  {
+    id: 'length',
+    label: 'Adequate length',
+    hint: 'At least 50 characters — one-liners never carry enough signal',
+    test: (s) => s.trim().length >= 50,
+    weight: 10,
+  },
+  {
+    id: 'purpose',
+    label: 'States what it does or returns',
+    hint: 'Mention what the tool retrieves, creates, or produces',
+    test: (s) =>
+      /\b(returns?|fetches?|retrieves?|gets?|creates?|searches?|finds?|lists?|generates?|sends?|calculates?|extracts?|converts?)\b/i.test(
+        s,
+      ),
+    weight: 20,
+  },
+  {
+    id: 'when',
+    label: 'Explains when to use it',
+    hint: '"Use when...", "to get...", or a concrete use-case sentence',
+    test: (s) =>
+      /\b(use when|use this when|use for|when you (need|want|have)|to (get|find|create|retrieve|fetch|search)|for (getting|finding|searching|retrieving))\b/i.test(
+        s,
+      ),
+    weight: 20,
+  },
+  {
+    id: 'antipattern',
+    label: 'Anti-patterns listed',
+    hint: '"Do NOT use for X — use Y() instead"',
+    test: (s) =>
+      /\b(do not use|don'?t use|not for|avoid using|instead use|use .+ instead)\b/i.test(
+        s,
+      ),
+    weight: 30,
+  },
+  {
+    id: 'params',
+    label: 'Required inputs mentioned',
+    hint: 'Reference required parameters or context',
+    test: (s) =>
+      /\b(requires?|needs?|expects?|must (have|provide|pass|supply)|with a valid|provide (a|an|the)|pass (a|an|the))\b/i.test(
+        s,
+      ),
+    weight: 20,
+  },
+]
+
+function ScoreTag({ score }: { score: number }) {
+  if (score >= 80)
+    return (
+      <span className="font-medium text-green-600 dark:text-green-400">
+        Good
+      </span>
+    )
+  if (score >= 50)
+    return (
+      <span className="font-medium text-yellow-600 dark:text-yellow-400">
+        Needs work
+      </span>
+    )
+  return (
+    <span className="font-medium text-red-600 dark:text-red-400">
+      Likely causing errors
+    </span>
+  )
+}
+
+export function ToolDescriptionGrader() {
+  const [input, setInput] = useState('')
+
+  const results = useMemo(() => {
+    const trimmed = input.trim()
+    if (!trimmed) return null
+    const checks = CHECKS.map((c) => ({ ...c, passed: c.test(trimmed) }))
+    const score = checks.reduce((sum, c) => sum + (c.passed ? c.weight : 0), 0)
+    return { checks, score }
+  }, [input])
+
+  const barColor = results
+    ? results.score >= 80
+      ? 'bg-green-500'
+      : results.score >= 50
+        ? 'bg-yellow-500'
+        : 'bg-red-500'
+    : 'bg-neutral-300 dark:bg-neutral-600'
+
+  return (
+    <div className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+        Tool Description Grader
+      </p>
+      <p className="mb-4 text-xs text-neutral-500 dark:text-neutral-400">
+        Paste a tool description to see what signal the model actually reads
+      </p>
+      <textarea
+        className="w-full rounded-lg border border-neutral-200 bg-white p-3 font-mono text-xs text-neutral-900 placeholder-neutral-400 focus:border-neutral-400 focus:outline-none dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder-neutral-600"
+        rows={3}
+        placeholder="Gets data for a user."
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+      />
+      {results && (
+        <div className="mt-3 space-y-3">
+          <div className="flex items-center gap-3">
+            <div className="h-2 flex-1 overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-700">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${barColor}`}
+                style={{ width: `${results.score}%` }}
+              />
+            </div>
+            <div className="w-36 text-right text-xs text-neutral-600 dark:text-neutral-400">
+              {results.score}/100 &mdash; <ScoreTag score={results.score} />
+            </div>
+          </div>
+          <ul className="space-y-1.5">
+            {results.checks.map((c) => (
+              <li key={c.id} className="flex items-start gap-2 text-xs">
+                <span
+                  className={`mt-px shrink-0 font-mono ${c.passed ? 'text-green-500' : 'text-neutral-300 dark:text-neutral-600'}`}
+                >
+                  {c.passed ? '✓' : '○'}
+                </span>
+                <span>
+                  <span
+                    className={
+                      c.passed
+                        ? 'text-neutral-700 dark:text-neutral-300'
+                        : 'text-neutral-400 dark:text-neutral-600'
+                    }
+                  >
+                    {c.label}
+                  </span>
+                  {!c.passed && (
+                    <span className="ml-1 text-neutral-400 dark:text-neutral-500">
+                      &mdash; {c.hint}
+                    </span>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/components/tool-scale-simulator.tsx
+++ b/app/components/tool-scale-simulator.tsx
@@ -1,0 +1,130 @@
+'use client'
+import React, { useState } from 'react'
+
+const ZONES = [
+  {
+    max: 5,
+    label: 'Safe zone',
+    color: 'green' as const,
+    desc: 'Reliable selection. Model can distinguish all tools. Focus on description quality, not architecture.',
+  },
+  {
+    max: 12,
+    label: 'Caution',
+    color: 'yellow' as const,
+    desc: 'Occasional wrong selection for semantically similar tools. Audit descriptions and add anti-patterns.',
+  },
+  {
+    max: 20,
+    label: 'Danger zone',
+    color: 'orange' as const,
+    desc: 'Consistent confusion between overlapping tools. Phantom function calls appear. A retrieval layer is overdue.',
+  },
+  {
+    max: Infinity,
+    label: 'Overloaded',
+    color: 'red' as const,
+    desc: 'Flat-list injection is unsafe at this scale. registry.query(context, top_k=8) is required.',
+  },
+]
+
+type Color = (typeof ZONES)[number]['color']
+
+const colorMap: Record<
+  Color,
+  { bar: string; text: string; bg: string; border: string }
+> = {
+  green: {
+    bar: 'bg-green-500',
+    text: 'text-green-700 dark:text-green-400',
+    bg: 'bg-green-50 dark:bg-green-950/40',
+    border: 'border-green-200 dark:border-green-900',
+  },
+  yellow: {
+    bar: 'bg-yellow-500',
+    text: 'text-yellow-700 dark:text-yellow-400',
+    bg: 'bg-yellow-50 dark:bg-yellow-950/40',
+    border: 'border-yellow-200 dark:border-yellow-900',
+  },
+  orange: {
+    bar: 'bg-orange-500',
+    text: 'text-orange-700 dark:text-orange-400',
+    bg: 'bg-orange-50 dark:bg-orange-950/40',
+    border: 'border-orange-200 dark:border-orange-900',
+  },
+  red: {
+    bar: 'bg-red-500',
+    text: 'text-red-700 dark:text-red-400',
+    bg: 'bg-red-50 dark:bg-red-950/40',
+    border: 'border-red-200 dark:border-red-900',
+  },
+}
+
+function getAccuracy(n: number): number {
+  if (n <= 5) return 97
+  if (n <= 12) return Math.round(97 - (n - 5) * 4.5)
+  if (n <= 20) return Math.round(65 - (n - 12) * 2.5)
+  return Math.max(18, Math.round(45 - (n - 20) * 1.3))
+}
+
+export function ToolScaleSimulator() {
+  const [count, setCount] = useState(8)
+
+  const zone = ZONES.find((z) => count <= z.max)!
+  const accuracy = getAccuracy(count)
+  const c = colorMap[zone.color]
+
+  return (
+    <div className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+        Tool Count Simulator
+      </p>
+      <p className="mb-4 text-xs text-neutral-500 dark:text-neutral-400">
+        Drag to change registry size and see estimated selection accuracy
+      </p>
+
+      <div className="mb-4 flex items-center gap-4">
+        <input
+          type="range"
+          min={1}
+          max={40}
+          value={count}
+          onChange={(e) => setCount(Number(e.target.value))}
+          className="flex-1 accent-neutral-700 dark:accent-neutral-300"
+        />
+        <span className="w-16 text-right text-2xl font-bold text-neutral-900 tabular-nums dark:text-white">
+          {count}
+        </span>
+      </div>
+
+      <div className="mb-3 grid grid-cols-2 gap-2">
+        <div className="rounded-lg border border-neutral-200 bg-white p-3 dark:border-neutral-700 dark:bg-neutral-950">
+          <p className="mb-1 text-xs text-neutral-500 dark:text-neutral-400">
+            Est. selection accuracy
+          </p>
+          <p className="text-xl font-bold text-neutral-900 dark:text-white">
+            {accuracy}%
+          </p>
+          <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-neutral-100 dark:bg-neutral-800">
+            <div
+              className="h-full rounded-full bg-blue-500 transition-all duration-500"
+              style={{ width: `${accuracy}%` }}
+            />
+          </div>
+        </div>
+        <div className={`rounded-lg border p-3 ${c.bg} ${c.border}`}>
+          <p className="mb-1 text-xs text-neutral-500 dark:text-neutral-400">
+            Status
+          </p>
+          <p className={`text-xl font-bold ${c.text}`}>{zone.label}</p>
+        </div>
+      </div>
+
+      <div
+        className={`rounded-lg border p-3 text-xs ${c.bg} ${c.border} ${c.text}`}
+      >
+        {zone.desc}
+      </div>
+    </div>
+  )
+}

--- a/app/components/verbosity-bias-demo.tsx
+++ b/app/components/verbosity-bias-demo.tsx
@@ -1,0 +1,115 @@
+'use client'
+import React, { useState } from 'react'
+
+const SHORT = {
+  label: 'Concise answer',
+  words: 6,
+  text: 'Paris is the capital of France.',
+  score: 5.1,
+}
+
+const VERBOSE = {
+  label: 'Padded answer',
+  words: 63,
+  text: "That's a great question! Paris, which has been the capital of France since the late 10th century, is indeed the capital of France. It serves as the country's political, economic, and cultural center. The city, situated along the Seine river, has a rich history spanning over 2,000 years and is home to iconic landmarks. To summarize: Paris is the capital of France.",
+  score: 8.2,
+}
+
+type State = 'idle' | 'judging' | 'done'
+
+export function VerbosityBiasDemo() {
+  const [flipped, setFlipped] = useState(false)
+  const [state, setState] = useState<State>('idle')
+
+  const a = flipped ? VERBOSE : SHORT
+  const b = flipped ? SHORT : VERBOSE
+
+  function runJudge() {
+    setState('judging')
+    setTimeout(() => setState('done'), 1400)
+  }
+
+  function swap() {
+    setFlipped((f) => !f)
+    setState('idle')
+  }
+
+  return (
+    <div className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+        Verbosity + Position Bias Demo
+      </p>
+      <p className="mb-1 text-xs text-neutral-500 dark:text-neutral-400">
+        Both responses are factually correct. Run the judge to see which wins.
+      </p>
+      <p className="mb-4 text-xs text-neutral-400 italic dark:text-neutral-600">
+        Q: What is the capital of France?
+      </p>
+
+      <div className="mb-4 grid grid-cols-2 gap-3">
+        {[a, b].map((ans, i) => (
+          <div
+            key={i}
+            className="flex flex-col rounded-lg border border-neutral-200 bg-white p-3 dark:border-neutral-700 dark:bg-neutral-950"
+          >
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-xs font-medium text-neutral-500">
+                Response {i === 0 ? 'A' : 'B'}
+              </span>
+              <span className="text-xs text-neutral-400">{ans.words}w</span>
+            </div>
+            <p className="flex-1 text-xs leading-relaxed text-neutral-700 dark:text-neutral-300">
+              {ans.text}
+            </p>
+            {state === 'done' && (
+              <div className="mt-3 border-t border-neutral-100 pt-3 dark:border-neutral-800">
+                <div className="mb-1 flex items-center justify-between">
+                  <span className="text-xs text-neutral-400">Judge score</span>
+                  <span
+                    className={`text-sm font-bold tabular-nums ${ans.score > 7 ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'}`}
+                  >
+                    {ans.score}/10
+                  </span>
+                </div>
+                <div className="h-1.5 overflow-hidden rounded-full bg-neutral-100 dark:bg-neutral-800">
+                  <div
+                    className={`h-full rounded-full transition-all duration-700 ${ans.score > 7 ? 'bg-green-500' : 'bg-red-400'}`}
+                    style={{ width: `${ans.score * 10}%` }}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          onClick={runJudge}
+          disabled={state === 'judging'}
+          className="flex-1 rounded-lg bg-neutral-900 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-neutral-700 disabled:opacity-50 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-200"
+        >
+          {state === 'judging'
+            ? 'Judging…'
+            : state === 'done'
+              ? 'Re-run judge'
+              : 'Run gpt-4o judge'}
+        </button>
+        <button
+          onClick={swap}
+          className="rounded-lg border border-neutral-200 px-3 py-2 text-xs font-medium text-neutral-600 transition-colors hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-800"
+        >
+          Swap order
+        </button>
+      </div>
+
+      {state === 'done' && (
+        <p className="mt-3 text-xs text-neutral-500 dark:text-neutral-400">
+          {flipped
+            ? 'Verbose answer is now in position A and still wins. Longer always beats shorter. Earlier always beats later. Both biases confirmed.'
+            : 'Verbose answer wins despite identical facts. Now swap the order — position B next.'}
+        </p>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- New blog post: *Your Eval Suite Is Lying to You*
- Exposes systematic LLM-as-a-judge biases: verbosity, position, self-preference, anchoring
- Contrarian pivot: operational metrics (rate limits, tool call success rate) are a bigger gap than quality metrics for most teams
- Bridges the research→engineering mindset shift on variance and eval cost
- Specific: cross-provider judging pattern, deterministic checks first, Gemini 2.5 Flash cost calculus

## Test plan

- [ ] Verify post renders correctly at `/blog/eval-suite-lying`
- [ ] Check all external links resolve
- [ ] Confirm frontmatter tags display correctly
- [ ] Review on mobile