### PR TITLE
blog: The Benchmark That Rewards Memorization Over Consistency

### DIFF
--- a/app/blog/[slug]/blog-post-client.tsx
+++ b/app/blog/[slug]/blog-post-client.tsx
@@ -13,6 +13,8 @@ import { formatDate, slugify } from 'app/blog/utils.shared'
 import { Code, GistCode } from 'app/components/code'
 import { VibeSimulator } from 'app/components/vibe-simulator'
 import { Callout } from 'app/components/callout'
+import { StatCallout } from 'app/components/stat-callout'
+import { LabeledCode } from 'app/components/labeled-code'
 import { LinkPreview } from 'app/components/link-preview'
 import { PostPreviewLink } from 'app/components/post-preview-link'
 import type { BlogPost, Heading } from 'app/blog/utils.shared'
@@ -87,6 +89,31 @@ const baseTinaComponents: Record<string, any> = {
     content?: string
   }) => <Callout type={type}>{content}</Callout>,
   GistCode: ({ url }: { url: string }) => <GistCode url={url} />,
+  StatCallout: ({
+    stat,
+    label,
+    source,
+    sourceUrl,
+  }: {
+    stat: string
+    label: string
+    source?: string
+    sourceUrl?: string
+  }) => (
+    <StatCallout
+      stat={stat}
+      label={label}
+      source={source}
+      sourceUrl={sourceUrl}
+    />
+  ),
+  LabeledCode: ({
+    type,
+    label,
+  }: {
+    type?: 'good' | 'bad' | 'note'
+    label: string
+  }) => <LabeledCode type={type} label={label} />,
 }
 
 interface BlogPostClientProps {

--- a/app/blog/[slug]/blog-post-client.tsx
+++ b/app/blog/[slug]/blog-post-client.tsx
@@ -15,6 +15,12 @@ import { VibeSimulator } from 'app/components/vibe-simulator'
 import { Callout } from 'app/components/callout'
 import { StatCallout } from 'app/components/stat-callout'
 import { LabeledCode } from 'app/components/labeled-code'
+import { ToolDescriptionGrader } from 'app/components/tool-description-grader'
+import { ToolScaleSimulator } from 'app/components/tool-scale-simulator'
+import { VerbosityBiasDemo } from 'app/components/verbosity-bias-demo'
+import { EvalCoverageMatrix } from 'app/components/eval-coverage-matrix'
+import { ConsistencyTradeoffExplorer } from 'app/components/consistency-tradeoff-explorer'
+import { BenchmarkBlindspots } from 'app/components/benchmark-blindspots'
 import { LinkPreview } from 'app/components/link-preview'
 import { PostPreviewLink } from 'app/components/post-preview-link'
 import type { BlogPost, Heading } from 'app/blog/utils.shared'
@@ -114,6 +120,12 @@ const baseTinaComponents: Record<string, any> = {
     type?: 'good' | 'bad' | 'note'
     label: string
   }) => <LabeledCode type={type} label={label} />,
+  ToolDescriptionGrader: () => <ToolDescriptionGrader />,
+  ToolScaleSimulator: () => <ToolScaleSimulator />,
+  VerbosityBiasDemo: () => <VerbosityBiasDemo />,
+  EvalCoverageMatrix: () => <EvalCoverageMatrix />,
+  ConsistencyTradeoffExplorer: () => <ConsistencyTradeoffExplorer />,
+  BenchmarkBlindspots: () => <BenchmarkBlindspots />,
 }
 
 interface BlogPostClientProps {

--- a/app/blog/posts/benchmark-memorization.mdx
+++ b/app/blog/posts/benchmark-memorization.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'The Benchmark That Rewards Memorization Over Consistency'
 publishedAt: '2026-04-22'
-summary: 'DINO-I scores favor fine-tuned models that have memorized a subject's texture — but texture memory is not subject consistency, and that confusion is holding back the field.'
+summary: "DINO-I scores favor fine-tuned models that have memorized a subject's texture — but texture memory is not subject consistency, and that confusion is holding back the field."
 tags:
   - machine-learning
   - diffusion-models

--- a/app/blog/posts/benchmark-memorization.mdx
+++ b/app/blog/posts/benchmark-memorization.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'The Benchmark That Rewards Memorization Over Consistency'
 publishedAt: '2026-04-22'
-summary: "DINO-I scores favor fine-tuned models that memorized a subject's texture — but texture memory is not subject consistency, and that confusion is holding back the field."
+summary: "DINO-I scores favor fine-tuned models that memorized a subject's texture, but texture memory is not subject consistency, and that confusion is holding back the field."
 tags:
   - machine-learning
   - diffusion-models
@@ -10,9 +10,9 @@ tags:
   - research
 ---
 
-The number was good. Better than good — our [DINO-I](https://arxiv.org/abs/2104.14294) score for [StorySync](https://arxiv.org/abs/2508.03735) was competitive with methods that had done per-subject fine-tuning, meaning they had literally trained on the subject's images before evaluation. We had not. We were comparing a method that sees your character for the first time at inference against methods that spent minutes or hours pre-memorizing them. And the gap was smaller than it should have been.
+The number was good. Better than good: our [DINO-I](https://arxiv.org/abs/2104.14294) score for [StorySync](https://arxiv.org/abs/2508.03735) was competitive with methods that had done per-subject fine-tuning, meaning they had literally trained on the subject's images before evaluation. We had not. We were comparing a method that sees your character for the first time at inference against methods that spent minutes or hours pre-memorizing them. And the gap was smaller than it should have been.
 
-That bothered me — but not for the reason you would expect.
+That bothered me, but not for the reason you would expect.
 
 It bothered me because we should have lost by more. DINO-I measures feature-level cosine similarity between a [DINOv2](https://dinov2.metademolab.com/)-encoded reference and generated images. It rewards texture reproduction: deep wrinkles on a face, exact fur pattern on a dog, specific stitch pattern on a jacket. Fine-tuning methods win this metric because they have seen those textures before. They are not being *consistent*; they are being *reproductive*. The distinction matters enormously, and the field is collapsing it.
 
@@ -26,7 +26,7 @@ The workflow that fine-tuned methods require:
 2. Run [DreamBooth](https://dreambooth.github.io/) or train a [LoRA](https://arxiv.org/abs/2106.09685) for several minutes to several hours
 3. Generate
 
-That works. The DINO-I scores are strong. But now you want a second character. Another fine-tune. A third character interacting with the first two. You are now managing three separate model checkpoints and hoping they compose correctly — which they frequently do not, because fine-tuning shifts model weights in ways that interfere when you try to merge or interpolate multiple LoRAs at inference.
+That works. The DINO-I scores are strong. But now you want a second character. Another fine-tune. A third character interacting with the first two. You are now managing three separate model checkpoints and hoping they compose correctly, which they frequently do not, because fine-tuning shifts model weights in ways that interfere when you try to merge or interpolate multiple LoRAs at inference.
 
 [FreeFuse](https://arxiv.org/abs/2510.23515) and similar work on LoRA fusion at test time exist precisely because this composition problem is so painful. The fact that a whole sub-field is dedicated to stitching fine-tuned adapters back together is a sign that the paradigm has a seam being papered over.
 
@@ -36,9 +36,9 @@ But run the standard benchmarks and training-free methods look worse. This is wh
 
 ## The attention leakage problem
 
-Cross-image attention sharing — the mechanism underlying most training-free consistency methods including StorySync — works by letting image patches attend to corresponding patches in a reference image during the diffusion denoising process. The intuition is right: you are letting the model "see" the reference while it generates. In practice, the mechanism has a sharp failure mode.
+Cross-image attention sharing (the mechanism underlying most training-free consistency methods including StorySync) works by letting image patches attend to corresponding patches in a reference image during the diffusion denoising process. The intuition is right: you are letting the model "see" the reference while it generates. In practice, the mechanism has a sharp failure mode.
 
-[Storybooth](https://arxiv.org/abs/2504.05800) named it precisely: **self-attention leakage**. When you have two subjects — say, a dog and a duck — and apply naive cross-frame attention sharing, the dog's tokens start attending to duck tokens because the attention mechanism does not respect subject boundaries. The dog picks up duck features. Both characters become visual averages of each other.
+[Storybooth](https://arxiv.org/abs/2504.05800) named it precisely: **self-attention leakage**. When you have two subjects (say, a dog and a duck) and apply naive cross-frame attention sharing, the dog's tokens start attending to duck tokens because the attention mechanism does not respect subject boundaries. The dog picks up duck features. Both characters become visual averages of each other.
 
 This is not a fringe case. It is the dominant failure mode at scale:
 
@@ -50,18 +50,18 @@ Storybooth's bounded cross-frame attention addresses this by constraining which 
 
 <StatCallout
   stat="107%"
-  label="improvement in character consistency over standard Stable Diffusion — and 31% over other leading training-free methods — by constraining cross-frame attention to subject boundaries"
+  label="improvement in character consistency over standard Stable Diffusion, and 31% over other leading training-free methods, by constraining cross-frame attention to subject boundaries"
   source="Storybooth, arxiv.org/abs/2504.05800"
   sourceUrl="https://arxiv.org/abs/2504.05800"
 />
 
-Our approach in StorySync was different: masked cross-image attention that localizes interaction to subject regions via segmentation masks, combined with a Regional Feature Harmonization step that explicitly reconciles fine-grained details within constrained regions. The Base Layout Interpolation component handles the opposite problem — keeping generated images from collapsing into clones of the reference, preserving compositional diversity.
+Our approach in StorySync was different: masked cross-image attention that localizes interaction to subject regions via segmentation masks, combined with a Regional Feature Harmonization step that explicitly reconciles fine-grained details within constrained regions. The Base Layout Interpolation component handles the opposite problem: keeping generated images from collapsing into clones of the reference, preserving compositional diversity.
 
 The tradeoff is real. You are buying diversity and zero-shot flexibility at the cost of some texture precision. DINO-I punishes this. Human evaluators, in my experience, care less about exact texture reproduction and more about *recognizability*: does this character feel like the same character? Those are different questions.
 
 ## Why benchmarks reward the wrong thing
 
-[IP-Adapter](https://ip-adapter.github.io/) is instructive. It is a popular lightweight alternative to full fine-tuning — an adapter that lets you condition generation on a reference image without per-subject training. Fast, flexible, results that look consistent at a glance. But IP-Adapter-Plus fails at text alignment when you compose it with complex prompts. The subject stays consistent; the scene goes wrong.
+[IP-Adapter](https://ip-adapter.github.io/) is instructive. It is a popular lightweight alternative to full fine-tuning: an adapter that lets you condition generation on a reference image without per-subject training. Fast, flexible, results that look consistent at a glance. But IP-Adapter-Plus fails at text alignment when you compose it with complex prompts. The subject stays consistent; the scene goes wrong.
 
 This is the dual failure mode to what training-free methods suffer from. Both DINO-I (subject fidelity) and CLIP-T (text alignment) are coarse proxies:
 
@@ -72,19 +72,19 @@ The [DreamBlend paper](https://arxiv.org/abs/2411.19390) calls this the "Pareto 
 
 ## What FLUX changed and what it did not
 
-[FLUX.1](https://blackforestlabs.ai/flux-1/)'s architecture — a rectified flow transformer with bidirectional attention across the full token sequence — handles long-range spatial coherence better than U-Net-based models. When we ran StorySync on FLUX.1-schnell, the baseline consistency was already better before any of our modifications. The model's MM-DiT blocks naturally encourage global coherence in a way that SD1.5 or even SDXL simply do not.
+[FLUX.1](https://blackforestlabs.ai/flux-1/)'s architecture (a rectified flow transformer with bidirectional attention across the full token sequence) handles long-range spatial coherence better than U-Net-based models. When we ran StorySync on FLUX.1-schnell, the baseline consistency was already better before any of our modifications. The model's MM-DiT blocks naturally encourage global coherence in a way that SD1.5 or even SDXL simply do not.
 
 <Callout type="note" content="FLUX.1-schnell's bidirectional attention means cross-image attention sharing integrates more smoothly than on U-Net architectures, where you have to carefully select which encoder layers to intervene in. The floor is higher, but the ceiling problem remains." />
 
 But FLUX did not solve subject consistency. It raised the floor. Attention leakage still appears. The texture-vs-recognizability tradeoff still exists. Five distinct characters still need careful attention masking. A better architecture is not a substitute for a principled consistency mechanism.
 
-[FreeCus](https://arxiv.org/abs/2507.15249) (ICCV 2025) showed this clearly — built specifically for Diffusion Transformers, exploiting what they call DiT's "dynamic shifting" for fine-grained feature extraction, and still needed explicit attention sharing mechanisms to achieve consistency.
+[FreeCus](https://arxiv.org/abs/2507.15249) (ICCV 2025) showed this clearly. Built specifically for Diffusion Transformers, exploiting DiT's "dynamic shifting" for fine-grained feature extraction, it still needed explicit attention sharing mechanisms to achieve consistency.
 
 ## The question the field should be asking
 
 Every subject consistency paper benchmarks against DreamBooth, IP-Adapter, and sometimes a few other fine-tuned baselines. Training-free methods usually lose on DINO-I by a few points. The authors note this limitation, say "training-free methods trade fidelity for flexibility," and move on.
 
-The benchmark setup — one subject, clean reference images, controlled evaluation — is not the use case anyone cares about in practice. The real scenario is:
+The benchmark setup (one subject, clean reference images, controlled evaluation) is not the use case anyone cares about in practice. The real scenario is:
 
 - Five characters in a visual story
 - Diverse poses and environments across scenes
@@ -93,4 +93,4 @@ The benchmark setup — one subject, clean reference images, controlled evaluati
 
 No existing benchmark evaluates that scenario well. DINO-I does not capture multi-subject interaction quality. CLIP-T does not capture scene-level coherence across a sequence. Human evaluations are expensive and rarely standardized across papers.
 
-Until the benchmarks catch up to the actual use case, the "training-free methods keep losing" narrative will persist — even as those methods solve harder problems. That is the more honest framing for where the research frontier actually is.
+Until the benchmarks catch up to the actual use case, the "training-free methods keep losing" narrative will persist, even as those methods solve harder problems. That is the more honest framing for where the research frontier actually is.

--- a/app/blog/posts/benchmark-memorization.mdx
+++ b/app/blog/posts/benchmark-memorization.mdx
@@ -10,82 +10,87 @@ tags:
   - research
 ---
 
-The number was good. Better than good — our [DINO-I](https://arxiv.org/abs/2104.14294) score for [StorySync](https://arxiv.org/abs/2508.03735) was competitive with methods that had done per-subject fine-tuning, which meant they had literally trained on the subject's images before evaluation. We hadn't. We were comparing a method that sees your character for the first time at inference against methods that spent minutes (or hours) pre-memorizing them. And the gap was smaller than it should have been.
+The number was good. Better than good — our [DINO-I](https://arxiv.org/abs/2104.14294) score for [StorySync](https://arxiv.org/abs/2508.03735) was competitive with methods that had done per-subject fine-tuning, meaning they had literally trained on the subject's images before evaluation. We had not. We were comparing a method that sees your character for the first time at inference against methods that spent minutes or hours pre-memorizing them. And the gap was smaller than it should have been.
 
-That bothered me — but not for the reason you'd expect.
+That bothered me — but not for the reason you would expect.
 
-It bothered me because we should have lost by more. Because what DINO-I actually measures — feature-level cosine similarity between a [DINOv2](https://dinov2.metademolab.com/)-encoded reference and generated images — rewards texture reproduction. Deep wrinkles on a face. Exact fur pattern on a dog. Specific stitch pattern on a jacket. Fine-tuning methods win this metric because they've seen those textures before. They're not being *consistent*; they're being *reproductive*. The distinction matters enormously, and the field is collapsing it.
+It bothered me because we should have lost by more. DINO-I measures feature-level cosine similarity between a [DINOv2](https://dinov2.metademolab.com/)-encoded reference and generated images. It rewards texture reproduction: deep wrinkles on a face, exact fur pattern on a dog, specific stitch pattern on a jacket. Fine-tuning methods win this metric because they have seen those textures before. They are not being *consistent*; they are being *reproductive*. The distinction matters enormously, and the field is collapsing it.
 
-## What "consistent" actually means when you're building a story
+## What "consistent" actually means when building a story
 
-When I was working on [StorySync](https://arxiv.org/abs/2508.03735), the motivating use case was visual storytelling: generate a sequence of scenes with the same character — same person, same dog, same robot — across different contexts, poses, lighting conditions, and backgrounds. A children's book. A comic strip. A product shoot with ten different environments.
+When working on [StorySync](https://arxiv.org/abs/2508.03735), the motivating use case was visual storytelling: generate a sequence of scenes with the same character across different contexts, poses, lighting conditions, and backgrounds. A children's book. A comic strip. A product shoot with ten different environments.
 
-The workflow that fine-tuned methods require looks like this:
+The workflow that fine-tuned methods require:
 
-1. Collect 15–30 images of your subject
+1. Collect 15 to 30 images of your subject
 2. Run [DreamBooth](https://dreambooth.github.io/) or train a [LoRA](https://arxiv.org/abs/2106.09685) for several minutes to several hours
 3. Generate
 
-That works. The DINO-I scores are strong. But now you want a second character. Another fine-tune. A third character interacting with the first two. You're now managing three separate model checkpoints and hoping they compose correctly — which they frequently don't, because fine-tuning shifts model weights in ways that interfere when you try to merge or interpolate multiple LoRAs at inference.
+That works. The DINO-I scores are strong. But now you want a second character. Another fine-tune. A third character interacting with the first two. You are now managing three separate model checkpoints and hoping they compose correctly — which they frequently do not, because fine-tuning shifts model weights in ways that interfere when you try to merge or interpolate multiple LoRAs at inference.
 
-[FreeFuse](https://arxiv.org/abs/2510.23515) and similar work on LoRA fusion at test time exist precisely because this composition problem is so painful. The fact that we need a whole sub-field dedicated to stitching fine-tuned adapters back together is a sign that the paradigm has a seam we're papering over.
+[FreeFuse](https://arxiv.org/abs/2510.23515) and similar work on LoRA fusion at test time exist precisely because this composition problem is so painful. The fact that a whole sub-field is dedicated to stitching fine-tuned adapters back together is a sign that the paradigm has a seam being papered over.
 
-Training-free methods don't have this problem. StorySync works on SDXL, Kandinsky 3, and FLUX.1-schnell without touching any weights. You give it reference images at inference time and it handles the rest via masked cross-image attention sharing and Regional Feature Harmonization. The model's internal representations do the work; nothing gets baked in.
+Training-free methods do not have this problem. StorySync works on SDXL, Kandinsky 3, and FLUX.1-schnell without touching any weights. You give it reference images at inference time and it handles the rest via masked cross-image attention sharing and Regional Feature Harmonization. The model's internal representations do the work; nothing gets baked in.
 
-But if you run the standard benchmarks, training-free methods look worse. And this is where I think the field is misleading itself.
+But run the standard benchmarks and training-free methods look worse. This is where I think the field is misleading itself.
 
-## The attention leakage problem nobody talks about clearly
+## The attention leakage problem
 
-Cross-image attention sharing — the mechanism underlying most training-free consistency methods, including StorySync — works by letting image patches attend to corresponding patches in a reference image during the diffusion denoising process. The intuition is right: you're letting the model "see" the reference while it generates. In practice, the mechanism has a sharp failure mode.
+Cross-image attention sharing — the mechanism underlying most training-free consistency methods including StorySync — works by letting image patches attend to corresponding patches in a reference image during the diffusion denoising process. The intuition is right: you are letting the model "see" the reference while it generates. In practice, the mechanism has a sharp failure mode.
 
-[Storybooth](https://arxiv.org/abs/2504.05800) named it precisely: **self-attention leakage**. When you have two subjects — say, a dog and a duck — and you apply naive cross-frame attention sharing, the dog's tokens start attending to duck tokens because the attention mechanism doesn't respect subject boundaries. The dog picks up duck features. The result looks consistent in a disturbing way: both characters become averages of each other.
+[Storybooth](https://arxiv.org/abs/2504.05800) named it precisely: **self-attention leakage**. When you have two subjects — say, a dog and a duck — and apply naive cross-frame attention sharing, the dog's tokens start attending to duck tokens because the attention mechanism does not respect subject boundaries. The dog picks up duck features. Both characters become visual averages of each other.
 
-This isn't a fringe failure case. It's the dominant failure mode at scale:
+This is not a fringe case. It is the dominant failure mode at scale:
 
-| Subjects | Failure severity |
-|----------|-----------------|
-| 2 | Manageable with careful masking |
-| 3–4 | Noticeable feature blending |
-| 5+ | Severe — characters converge to visual average |
+- **2 subjects:** manageable with careful masking
+- **3 to 4 subjects:** noticeable feature blending, requires explicit boundary enforcement
+- **5 or more:** characters visually converge without aggressive segmentation
 
-Storybooth's bounded cross-frame attention addresses this by constraining which tokens can attend to which, reporting a **107% improvement in character consistency** over standard Stable Diffusion and 31% over other leading training-free approaches.
+Storybooth's bounded cross-frame attention addresses this by constraining which tokens can attend to which.
+
+<StatCallout
+  stat="107%"
+  label="improvement in character consistency over standard Stable Diffusion — and 31% over other leading training-free methods — by constraining cross-frame attention to subject boundaries"
+  source="Storybooth, arxiv.org/abs/2504.05800"
+  sourceUrl="https://arxiv.org/abs/2504.05800"
+/>
 
 Our approach in StorySync was different: masked cross-image attention that localizes interaction to subject regions via segmentation masks, combined with a Regional Feature Harmonization step that explicitly reconciles fine-grained details within constrained regions. The Base Layout Interpolation component handles the opposite problem — keeping generated images from collapsing into clones of the reference, preserving compositional diversity.
 
-The tradeoff is real. You're buying diversity and zero-shot flexibility at the cost of some texture precision. DINO-I punishes this. Human evaluators, in my experience, care less about exact texture reproduction and more about *recognizability*: does this character feel like the same character? Those are different questions, and no current benchmark measures the second one well.
+The tradeoff is real. You are buying diversity and zero-shot flexibility at the cost of some texture precision. DINO-I punishes this. Human evaluators, in my experience, care less about exact texture reproduction and more about *recognizability*: does this character feel like the same character? Those are different questions.
 
 ## Why benchmarks reward the wrong thing
 
-[IP-Adapter](https://ip-adapter.github.io/) is instructive here. It's a popular lightweight alternative to full fine-tuning — an adapter trained on a large dataset that lets you condition generation on a reference image without per-subject training. Fast, flexible, produces results that look consistent at a glance. But the research community found that IP-Adapter-Plus fails at text alignment when you try to compose it with complex prompts. The subject stays consistent; the scene goes wrong.
+[IP-Adapter](https://ip-adapter.github.io/) is instructive. It is a popular lightweight alternative to full fine-tuning — an adapter that lets you condition generation on a reference image without per-subject training. Fast, flexible, results that look consistent at a glance. But IP-Adapter-Plus fails at text alignment when you compose it with complex prompts. The subject stays consistent; the scene goes wrong.
 
 This is the dual failure mode to what training-free methods suffer from. Both DINO-I (subject fidelity) and CLIP-T (text alignment) are coarse proxies:
 
-- A method can score well on **DINO-I** by memorizing surface texture while quietly losing semantic coherence in complex multi-subject scenes
+- A method can score well on **DINO-I** by memorizing surface texture while losing semantic coherence in complex multi-subject scenes
 - A method can score well on **CLIP-T** by ignoring subject details and just following the prompt faithfully
 
-The [DreamBlend paper](https://arxiv.org/abs/2411.19390) calls this the "Pareto front" between subject fidelity and text fidelity — an honest framing. What frustrates me is that the community mostly reports numbers as if one axis dominates, picks the method that wins its preferred metric, and moves on. The systems that actually work in production have to navigate this tradeoff explicitly, and the benchmarks give almost no guidance for how.
+The [DreamBlend paper](https://arxiv.org/abs/2411.19390) calls this the "Pareto front" between subject fidelity and text fidelity. The framing is honest. What is frustrating is that the community mostly reports numbers as if one axis dominates, picks the method that wins its preferred metric, and moves on. The systems that actually work in production have to navigate this tradeoff explicitly, and the benchmarks give almost no guidance for how.
 
-## What FLUX changed and what it didn't
+## What FLUX changed and what it did not
 
-[FLUX.1](https://blackforestlabs.ai/flux-1/)'s architecture — a rectified flow transformer with bidirectional attention across the full token sequence — handles long-range spatial coherence better than U-Net-based models. When we ran StorySync on FLUX.1-schnell, the baseline consistency was already better before any of our modifications. The model's MM-DiT blocks naturally encourage global coherence in a way that SD1.5 or even SDXL simply don't.
+[FLUX.1](https://blackforestlabs.ai/flux-1/)'s architecture — a rectified flow transformer with bidirectional attention across the full token sequence — handles long-range spatial coherence better than U-Net-based models. When we ran StorySync on FLUX.1-schnell, the baseline consistency was already better before any of our modifications. The model's MM-DiT blocks naturally encourage global coherence in a way that SD1.5 or even SDXL simply do not.
 
 <Callout type="note" content="FLUX.1-schnell's bidirectional attention means cross-image attention sharing integrates more smoothly than on U-Net architectures, where you have to carefully select which encoder layers to intervene in. The floor is higher, but the ceiling problem remains." />
 
-But FLUX didn't solve subject consistency. It raised the floor. Attention leakage still appears. The texture-vs-recognizability tradeoff still exists. You still can't do training-free multi-subject generation with five distinct characters without careful attention masking. A better architecture is not a substitute for a principled consistency mechanism.
+But FLUX did not solve subject consistency. It raised the floor. Attention leakage still appears. The texture-vs-recognizability tradeoff still exists. Five distinct characters still need careful attention masking. A better architecture is not a substitute for a principled consistency mechanism.
 
-[FreeCus](https://arxiv.org/abs/2507.15249) (ICCV 2025) showed this clearly — they built their training-free approach specifically for Diffusion Transformers, exploiting what they call DiT's "dynamic shifting" for fine-grained feature extraction, and still needed explicit attention sharing mechanisms to achieve consistency.
+[FreeCus](https://arxiv.org/abs/2507.15249) (ICCV 2025) showed this clearly — built specifically for Diffusion Transformers, exploiting what they call DiT's "dynamic shifting" for fine-grained feature extraction, and still needed explicit attention sharing mechanisms to achieve consistency.
 
 ## The question the field should be asking
 
-Every subject consistency paper benchmarks against DreamBooth, IP-Adapter, and sometimes a few other fine-tuned baselines. The training-free methods usually lose on DINO-I by a few points. The authors note this limitation, say "training-free methods trade fidelity for flexibility," and move on.
+Every subject consistency paper benchmarks against DreamBooth, IP-Adapter, and sometimes a few other fine-tuned baselines. Training-free methods usually lose on DINO-I by a few points. The authors note this limitation, say "training-free methods trade fidelity for flexibility," and move on.
 
-I think we're asking the wrong question. The benchmark setup — one subject, clean reference images, controlled evaluation — is not the use case anyone cares about in practice. The real scenario is:
+The benchmark setup — one subject, clean reference images, controlled evaluation — is not the use case anyone cares about in practice. The real scenario is:
 
 - Five characters in a visual story
 - Diverse poses and environments across scenes
 - Reference images that might themselves be generated (already slightly inconsistent)
 - A hard constraint that you cannot spend two hours on per-subject fine-tuning before generation
 
-No existing benchmark evaluates that scenario well. DINO-I doesn't capture multi-subject interaction quality. CLIP-T doesn't capture scene-level coherence across a sequence. Human evaluations are expensive and rarely standardized across papers.
+No existing benchmark evaluates that scenario well. DINO-I does not capture multi-subject interaction quality. CLIP-T does not capture scene-level coherence across a sequence. Human evaluations are expensive and rarely standardized across papers.
 
-Until the benchmarks catch up to the actual use case, the "training-free methods keep losing" narrative will persist — even as those methods solve harder problems. That seems like the more honest framing for where the research frontier actually is.
+Until the benchmarks catch up to the actual use case, the "training-free methods keep losing" narrative will persist — even as those methods solve harder problems. That is the more honest framing for where the research frontier actually is.

--- a/app/blog/posts/benchmark-memorization.mdx
+++ b/app/blog/posts/benchmark-memorization.mdx
@@ -1,0 +1,69 @@
+---
+title: 'The Benchmark That Rewards Memorization Over Consistency'
+publishedAt: '2026-04-22'
+summary: 'DINO-I scores favor fine-tuned models that have memorized a subject's texture — but texture memory is not subject consistency, and that confusion is holding back the field.'
+tags:
+  - machine-learning
+  - diffusion-models
+  - text-to-image
+  - generative-ai
+  - research
+---
+
+The number was good. Better than good, actually — our DINO-I score for StorySync was competitive with methods that had done per-subject fine-tuning, which meant they had literally trained on the subject's images before evaluation. We hadn't. We were comparing a method that sees your character for the first time at inference against methods that spent minutes (or hours) pre-memorizing them. And the gap was smaller than it should have been.
+
+That bothered me, but not for the reason you'd expect.
+
+It bothered me because we should have lost by more. Because what DINO-I actually measures — feature-level cosine similarity between a DINOv2-encoded reference and generated images — rewards texture reproduction. Deep wrinkles on a face. Exact fur pattern on a dog. Specific stitch pattern on a jacket. Fine-tuning methods win this metric because they've seen those textures before. They're not being consistent; they're being reproductive. The distinction matters enormously, and the field is collapsing it.
+
+## What "consistent" actually means when you're building a story
+
+When I was working on [StorySync](https://arxiv.org/abs/2508.03735), the motivating use case was visual storytelling: generate a sequence of scenes with the same character — same person, same dog, same robot — across different contexts, poses, lighting conditions, and backgrounds. A children's book. A comic strip. A product shoot with ten different environments.
+
+The workflow that fine-tuned methods support looks like this: collect 15–30 images of your subject, run DreamBooth or train a LoRA for several minutes to several hours, then generate. That works. The DINO-I scores are strong. But now you want a second character. Another fine-tune. A third character interacting with the first two. You're now managing three separate model checkpoints and hoping they compose correctly — which they frequently don't, because fine-tuning shifts the model's weights in ways that interfere when you try to merge or interpolate multiple LoRAs at inference.
+
+[FreeFuse](https://arxiv.org/abs/2510.23515) and similar work on LoRA fusion at test time exist precisely because this composition problem is so painful. The fact that we need a whole sub-field dedicated to stitching fine-tuned adapters back together is a sign that the paradigm has a seam we're papering over.
+
+Training-free methods don't have this problem. They're plug-and-play by construction — StorySync works on SDXL, Kandinsky 3, and FLUX.1-schnell without touching any weights. You give it reference images at inference time and it handles the rest via masked cross-image attention sharing and Regional Feature Harmonization. The model's internal representations do the work; nothing gets baked in.
+
+But if you run the standard benchmarks, training-free methods look worse. And this is where I think the field is misleading itself.
+
+## The attention leakage problem nobody talks about clearly
+
+Cross-image attention sharing — the mechanism underlying most training-free consistency methods, including StorySync — works by letting image patches attend to corresponding patches in a reference image during the diffusion denoising process. The intuition is right: you're letting the model "see" the reference while it generates. In practice, the mechanism has a sharp failure mode.
+
+[Storybooth](https://arxiv.org/abs/2504.05800) named it precisely: self-attention leakage. When you have two subjects — say, a dog and a duck — and you apply naive cross-frame attention sharing, the dog's tokens start attending to duck tokens because the attention mechanism doesn't respect subject boundaries. The dog picks up duck features. The result looks consistent in a disturbing way: both characters become averages of each other.
+
+This isn't a fringe failure case. It's the dominant failure mode at scale, and it scales badly — two subjects is manageable, five subjects is a mess. Storybooth's bounded cross-frame attention addresses it by constraining which tokens can attend to which, and they report a 107% improvement in character consistency over standard Stable Diffusion and 31% over other leading approaches. But "leading approaches" here means previous training-free methods, not fine-tuned ones. Against DreamBooth with five subjects and proper LoRA merging, the comparison is murkier.
+
+Our approach in StorySync was different: rather than bounding attention globally, we use masked cross-image attention that localizes interaction to subject regions via segmentation masks, combined with a Regional Feature Harmonization step that explicitly reconciles fine-grained details — the texture layer that DINO-I cares about — within the constrained regions. The Base Layout Interpolation component then handles the opposite problem: keeping generated images from collapsing into clones of the reference, preserving compositional diversity.
+
+The tradeoff is real. You're buying diversity and zero-shot flexibility at the cost of some texture precision. DINO-I punishes this. Human evaluators, in my experience, care less about exact texture reproduction and more about *recognizability* — does this character feel like the same character? Those are different questions.
+
+## Why benchmarks reward the wrong thing
+
+[IP-Adapter](https://ip-adapter.github.io/) is instructive here. It's a popular lightweight alternative to full fine-tuning — an adapter trained on a large dataset that lets you condition generation on a reference image. IP-Adapter is fast, doesn't require per-subject training, and produces results that look consistent at a glance. But the research community found that IP-Adapter-Plus fails at text alignment when you try to compose it with complex prompts. The subject stays consistent; the scene goes wrong.
+
+This is the dual failure mode to what training-free methods suffer from. Both DINO-I (subject fidelity) and CLIP-T (text alignment) are coarse proxies. A method can score well on DINO-I by memorizing surface texture while quietly losing semantic coherence in complex multi-subject scenes. A method can score well on CLIP-T by ignoring subject details and just following the prompt faithfully. Getting both high is a legitimate challenge — but the benchmarks don't capture what users actually want: a character who *feels* like themselves in a scene that *looks* like the prompt described.
+
+The [DreamBlend paper](https://arxiv.org/abs/2411.19390) calls this the "Pareto front" between subject fidelity and text fidelity. The framing is honest. What frustrates me is that the community mostly reports numbers as if one axis dominates, picks the method that wins its preferred metric, and moves on. The systems that actually work in production have to navigate this tradeoff explicitly, and the benchmarks give almost no guidance for how.
+
+## What FLUX changed and what it didn't
+
+FLUX.1's architecture — a rectified flow transformer with bidirectional attention across the full token sequence — handles long-range spatial coherence better than U-Net-based models. When we ran StorySync on FLUX.1-schnell, the baseline consistency was already better before any of our modifications. The model's MM-DiT blocks naturally encourage global coherence in a way that SD1.5 or even SDXL simply don't.
+
+<Callout type="note" content="FLUX.1-schnell's bidirectional attention means that cross-image attention sharing integrates more smoothly than on U-Net architectures, where you have to carefully pick which encoder layers to intervene in." />
+
+But FLUX didn't solve subject consistency. It raised the floor. The attention leakage problem still appears. The texture-vs-recognizability tradeoff still exists. You still can't do training-free multi-subject generation with five distinct characters without careful attention masking. The architecture is better, but the problem is not solved by the architecture alone.
+
+[FreeCus](https://arxiv.org/abs/2507.15249) (ICCV 2025) showed this clearly — they built their training-free approach specifically for Diffusion Transformers, exploiting what they call DiT's "dynamic shifting" for fine-grained feature extraction, and still needed explicit attention sharing mechanisms to achieve consistency. A better architecture is not a substitute for a principled consistency mechanism.
+
+## The question the field should be asking
+
+Every subject consistency paper benchmarks against DreamBooth, IP-Adapter, and sometimes a few other fine-tuned baselines. The training-free methods usually lose on DINO-I by a few points. The authors note this limitation, say "training-free methods trade fidelity for flexibility," and move on.
+
+I think we're asking the wrong question. The benchmark setup — one subject, clean reference images, controlled evaluation — is not the use case anyone cares about in practice. The real scenario is: five characters in a visual story, diverse poses and environments, reference images that might be other generated images (so already slightly inconsistent), and a hard constraint that you cannot spend two hours on per-subject fine-tuning before generation.
+
+No existing benchmark evaluates that scenario well. DINO-I doesn't capture multi-subject interaction quality. CLIP-T doesn't capture scene-level coherence across a sequence. Human evaluations are expensive and rarely standardized across papers.
+
+Until the benchmarks catch up to the actual use case, the "training-free methods keep losing" narrative will persist — even as those methods solve harder problems. That seems like the more honest framing for where the research frontier actually is.

--- a/app/blog/posts/benchmark-memorization.mdx
+++ b/app/blog/posts/benchmark-memorization.mdx
@@ -59,6 +59,8 @@ Our approach in StorySync was different: masked cross-image attention that local
 
 The tradeoff is real. You are buying diversity and zero-shot flexibility at the cost of some texture precision. DINO-I punishes this. Human evaluators, in my experience, care less about exact texture reproduction and more about *recognizability*: does this character feel like the same character? Those are different questions.
 
+<ConsistencyTradeoffExplorer />
+
 ## Why benchmarks reward the wrong thing
 
 [IP-Adapter](https://ip-adapter.github.io/) is instructive. It is a popular lightweight alternative to full fine-tuning: an adapter that lets you condition generation on a reference image without per-subject training. Fast, flexible, results that look consistent at a glance. But IP-Adapter-Plus fails at text alignment when you compose it with complex prompts. The subject stays consistent; the scene goes wrong.
@@ -92,5 +94,7 @@ The benchmark setup (one subject, clean reference images, controlled evaluation)
 - A hard constraint that you cannot spend two hours on per-subject fine-tuning before generation
 
 No existing benchmark evaluates that scenario well. DINO-I does not capture multi-subject interaction quality. CLIP-T does not capture scene-level coherence across a sequence. Human evaluations are expensive and rarely standardized across papers.
+
+<BenchmarkBlindspots />
 
 Until the benchmarks catch up to the actual use case, the "training-free methods keep losing" narrative will persist, even as those methods solve harder problems. That is the more honest framing for where the research frontier actually is.

--- a/app/blog/posts/benchmark-memorization.mdx
+++ b/app/blog/posts/benchmark-memorization.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'The Benchmark That Rewards Memorization Over Consistency'
 publishedAt: '2026-04-22'
-summary: "DINO-I scores favor fine-tuned models that have memorized a subject's texture — but texture memory is not subject consistency, and that confusion is holding back the field."
+summary: "DINO-I scores favor fine-tuned models that memorized a subject's texture — but texture memory is not subject consistency, and that confusion is holding back the field."
 tags:
   - machine-learning
   - diffusion-models
@@ -10,21 +10,27 @@ tags:
   - research
 ---
 
-The number was good. Better than good, actually — our DINO-I score for StorySync was competitive with methods that had done per-subject fine-tuning, which meant they had literally trained on the subject's images before evaluation. We hadn't. We were comparing a method that sees your character for the first time at inference against methods that spent minutes (or hours) pre-memorizing them. And the gap was smaller than it should have been.
+The number was good. Better than good — our [DINO-I](https://arxiv.org/abs/2104.14294) score for [StorySync](https://arxiv.org/abs/2508.03735) was competitive with methods that had done per-subject fine-tuning, which meant they had literally trained on the subject's images before evaluation. We hadn't. We were comparing a method that sees your character for the first time at inference against methods that spent minutes (or hours) pre-memorizing them. And the gap was smaller than it should have been.
 
-That bothered me, but not for the reason you'd expect.
+That bothered me — but not for the reason you'd expect.
 
-It bothered me because we should have lost by more. Because what DINO-I actually measures — feature-level cosine similarity between a DINOv2-encoded reference and generated images — rewards texture reproduction. Deep wrinkles on a face. Exact fur pattern on a dog. Specific stitch pattern on a jacket. Fine-tuning methods win this metric because they've seen those textures before. They're not being consistent; they're being reproductive. The distinction matters enormously, and the field is collapsing it.
+It bothered me because we should have lost by more. Because what DINO-I actually measures — feature-level cosine similarity between a [DINOv2](https://dinov2.metademolab.com/)-encoded reference and generated images — rewards texture reproduction. Deep wrinkles on a face. Exact fur pattern on a dog. Specific stitch pattern on a jacket. Fine-tuning methods win this metric because they've seen those textures before. They're not being *consistent*; they're being *reproductive*. The distinction matters enormously, and the field is collapsing it.
 
 ## What "consistent" actually means when you're building a story
 
 When I was working on [StorySync](https://arxiv.org/abs/2508.03735), the motivating use case was visual storytelling: generate a sequence of scenes with the same character — same person, same dog, same robot — across different contexts, poses, lighting conditions, and backgrounds. A children's book. A comic strip. A product shoot with ten different environments.
 
-The workflow that fine-tuned methods support looks like this: collect 15–30 images of your subject, run DreamBooth or train a LoRA for several minutes to several hours, then generate. That works. The DINO-I scores are strong. But now you want a second character. Another fine-tune. A third character interacting with the first two. You're now managing three separate model checkpoints and hoping they compose correctly — which they frequently don't, because fine-tuning shifts the model's weights in ways that interfere when you try to merge or interpolate multiple LoRAs at inference.
+The workflow that fine-tuned methods require looks like this:
+
+1. Collect 15–30 images of your subject
+2. Run [DreamBooth](https://dreambooth.github.io/) or train a [LoRA](https://arxiv.org/abs/2106.09685) for several minutes to several hours
+3. Generate
+
+That works. The DINO-I scores are strong. But now you want a second character. Another fine-tune. A third character interacting with the first two. You're now managing three separate model checkpoints and hoping they compose correctly — which they frequently don't, because fine-tuning shifts model weights in ways that interfere when you try to merge or interpolate multiple LoRAs at inference.
 
 [FreeFuse](https://arxiv.org/abs/2510.23515) and similar work on LoRA fusion at test time exist precisely because this composition problem is so painful. The fact that we need a whole sub-field dedicated to stitching fine-tuned adapters back together is a sign that the paradigm has a seam we're papering over.
 
-Training-free methods don't have this problem. They're plug-and-play by construction — StorySync works on SDXL, Kandinsky 3, and FLUX.1-schnell without touching any weights. You give it reference images at inference time and it handles the rest via masked cross-image attention sharing and Regional Feature Harmonization. The model's internal representations do the work; nothing gets baked in.
+Training-free methods don't have this problem. StorySync works on SDXL, Kandinsky 3, and FLUX.1-schnell without touching any weights. You give it reference images at inference time and it handles the rest via masked cross-image attention sharing and Regional Feature Harmonization. The model's internal representations do the work; nothing gets baked in.
 
 But if you run the standard benchmarks, training-free methods look worse. And this is where I think the field is misleading itself.
 
@@ -32,37 +38,53 @@ But if you run the standard benchmarks, training-free methods look worse. And th
 
 Cross-image attention sharing — the mechanism underlying most training-free consistency methods, including StorySync — works by letting image patches attend to corresponding patches in a reference image during the diffusion denoising process. The intuition is right: you're letting the model "see" the reference while it generates. In practice, the mechanism has a sharp failure mode.
 
-[Storybooth](https://arxiv.org/abs/2504.05800) named it precisely: self-attention leakage. When you have two subjects — say, a dog and a duck — and you apply naive cross-frame attention sharing, the dog's tokens start attending to duck tokens because the attention mechanism doesn't respect subject boundaries. The dog picks up duck features. The result looks consistent in a disturbing way: both characters become averages of each other.
+[Storybooth](https://arxiv.org/abs/2504.05800) named it precisely: **self-attention leakage**. When you have two subjects — say, a dog and a duck — and you apply naive cross-frame attention sharing, the dog's tokens start attending to duck tokens because the attention mechanism doesn't respect subject boundaries. The dog picks up duck features. The result looks consistent in a disturbing way: both characters become averages of each other.
 
-This isn't a fringe failure case. It's the dominant failure mode at scale, and it scales badly — two subjects is manageable, five subjects is a mess. Storybooth's bounded cross-frame attention addresses it by constraining which tokens can attend to which, and they report a 107% improvement in character consistency over standard Stable Diffusion and 31% over other leading approaches. But "leading approaches" here means previous training-free methods, not fine-tuned ones. Against DreamBooth with five subjects and proper LoRA merging, the comparison is murkier.
+This isn't a fringe failure case. It's the dominant failure mode at scale:
 
-Our approach in StorySync was different: rather than bounding attention globally, we use masked cross-image attention that localizes interaction to subject regions via segmentation masks, combined with a Regional Feature Harmonization step that explicitly reconciles fine-grained details — the texture layer that DINO-I cares about — within the constrained regions. The Base Layout Interpolation component then handles the opposite problem: keeping generated images from collapsing into clones of the reference, preserving compositional diversity.
+| Subjects | Failure severity |
+|----------|-----------------|
+| 2 | Manageable with careful masking |
+| 3–4 | Noticeable feature blending |
+| 5+ | Severe — characters converge to visual average |
 
-The tradeoff is real. You're buying diversity and zero-shot flexibility at the cost of some texture precision. DINO-I punishes this. Human evaluators, in my experience, care less about exact texture reproduction and more about *recognizability* — does this character feel like the same character? Those are different questions.
+Storybooth's bounded cross-frame attention addresses this by constraining which tokens can attend to which, reporting a **107% improvement in character consistency** over standard Stable Diffusion and 31% over other leading training-free approaches.
+
+Our approach in StorySync was different: masked cross-image attention that localizes interaction to subject regions via segmentation masks, combined with a Regional Feature Harmonization step that explicitly reconciles fine-grained details within constrained regions. The Base Layout Interpolation component handles the opposite problem — keeping generated images from collapsing into clones of the reference, preserving compositional diversity.
+
+The tradeoff is real. You're buying diversity and zero-shot flexibility at the cost of some texture precision. DINO-I punishes this. Human evaluators, in my experience, care less about exact texture reproduction and more about *recognizability*: does this character feel like the same character? Those are different questions, and no current benchmark measures the second one well.
 
 ## Why benchmarks reward the wrong thing
 
-[IP-Adapter](https://ip-adapter.github.io/) is instructive here. It's a popular lightweight alternative to full fine-tuning — an adapter trained on a large dataset that lets you condition generation on a reference image. IP-Adapter is fast, doesn't require per-subject training, and produces results that look consistent at a glance. But the research community found that IP-Adapter-Plus fails at text alignment when you try to compose it with complex prompts. The subject stays consistent; the scene goes wrong.
+[IP-Adapter](https://ip-adapter.github.io/) is instructive here. It's a popular lightweight alternative to full fine-tuning — an adapter trained on a large dataset that lets you condition generation on a reference image without per-subject training. Fast, flexible, produces results that look consistent at a glance. But the research community found that IP-Adapter-Plus fails at text alignment when you try to compose it with complex prompts. The subject stays consistent; the scene goes wrong.
 
-This is the dual failure mode to what training-free methods suffer from. Both DINO-I (subject fidelity) and CLIP-T (text alignment) are coarse proxies. A method can score well on DINO-I by memorizing surface texture while quietly losing semantic coherence in complex multi-subject scenes. A method can score well on CLIP-T by ignoring subject details and just following the prompt faithfully. Getting both high is a legitimate challenge — but the benchmarks don't capture what users actually want: a character who *feels* like themselves in a scene that *looks* like the prompt described.
+This is the dual failure mode to what training-free methods suffer from. Both DINO-I (subject fidelity) and CLIP-T (text alignment) are coarse proxies:
 
-The [DreamBlend paper](https://arxiv.org/abs/2411.19390) calls this the "Pareto front" between subject fidelity and text fidelity. The framing is honest. What frustrates me is that the community mostly reports numbers as if one axis dominates, picks the method that wins its preferred metric, and moves on. The systems that actually work in production have to navigate this tradeoff explicitly, and the benchmarks give almost no guidance for how.
+- A method can score well on **DINO-I** by memorizing surface texture while quietly losing semantic coherence in complex multi-subject scenes
+- A method can score well on **CLIP-T** by ignoring subject details and just following the prompt faithfully
+
+The [DreamBlend paper](https://arxiv.org/abs/2411.19390) calls this the "Pareto front" between subject fidelity and text fidelity — an honest framing. What frustrates me is that the community mostly reports numbers as if one axis dominates, picks the method that wins its preferred metric, and moves on. The systems that actually work in production have to navigate this tradeoff explicitly, and the benchmarks give almost no guidance for how.
 
 ## What FLUX changed and what it didn't
 
-FLUX.1's architecture — a rectified flow transformer with bidirectional attention across the full token sequence — handles long-range spatial coherence better than U-Net-based models. When we ran StorySync on FLUX.1-schnell, the baseline consistency was already better before any of our modifications. The model's MM-DiT blocks naturally encourage global coherence in a way that SD1.5 or even SDXL simply don't.
+[FLUX.1](https://blackforestlabs.ai/flux-1/)'s architecture — a rectified flow transformer with bidirectional attention across the full token sequence — handles long-range spatial coherence better than U-Net-based models. When we ran StorySync on FLUX.1-schnell, the baseline consistency was already better before any of our modifications. The model's MM-DiT blocks naturally encourage global coherence in a way that SD1.5 or even SDXL simply don't.
 
-<Callout type="note" content="FLUX.1-schnell's bidirectional attention means that cross-image attention sharing integrates more smoothly than on U-Net architectures, where you have to carefully pick which encoder layers to intervene in." />
+<Callout type="note" content="FLUX.1-schnell's bidirectional attention means cross-image attention sharing integrates more smoothly than on U-Net architectures, where you have to carefully select which encoder layers to intervene in. The floor is higher, but the ceiling problem remains." />
 
-But FLUX didn't solve subject consistency. It raised the floor. The attention leakage problem still appears. The texture-vs-recognizability tradeoff still exists. You still can't do training-free multi-subject generation with five distinct characters without careful attention masking. The architecture is better, but the problem is not solved by the architecture alone.
+But FLUX didn't solve subject consistency. It raised the floor. Attention leakage still appears. The texture-vs-recognizability tradeoff still exists. You still can't do training-free multi-subject generation with five distinct characters without careful attention masking. A better architecture is not a substitute for a principled consistency mechanism.
 
-[FreeCus](https://arxiv.org/abs/2507.15249) (ICCV 2025) showed this clearly — they built their training-free approach specifically for Diffusion Transformers, exploiting what they call DiT's "dynamic shifting" for fine-grained feature extraction, and still needed explicit attention sharing mechanisms to achieve consistency. A better architecture is not a substitute for a principled consistency mechanism.
+[FreeCus](https://arxiv.org/abs/2507.15249) (ICCV 2025) showed this clearly — they built their training-free approach specifically for Diffusion Transformers, exploiting what they call DiT's "dynamic shifting" for fine-grained feature extraction, and still needed explicit attention sharing mechanisms to achieve consistency.
 
 ## The question the field should be asking
 
 Every subject consistency paper benchmarks against DreamBooth, IP-Adapter, and sometimes a few other fine-tuned baselines. The training-free methods usually lose on DINO-I by a few points. The authors note this limitation, say "training-free methods trade fidelity for flexibility," and move on.
 
-I think we're asking the wrong question. The benchmark setup — one subject, clean reference images, controlled evaluation — is not the use case anyone cares about in practice. The real scenario is: five characters in a visual story, diverse poses and environments, reference images that might be other generated images (so already slightly inconsistent), and a hard constraint that you cannot spend two hours on per-subject fine-tuning before generation.
+I think we're asking the wrong question. The benchmark setup — one subject, clean reference images, controlled evaluation — is not the use case anyone cares about in practice. The real scenario is:
+
+- Five characters in a visual story
+- Diverse poses and environments across scenes
+- Reference images that might themselves be generated (already slightly inconsistent)
+- A hard constraint that you cannot spend two hours on per-subject fine-tuning before generation
 
 No existing benchmark evaluates that scenario well. DINO-I doesn't capture multi-subject interaction quality. CLIP-T doesn't capture scene-level coherence across a sequence. Human evaluations are expensive and rarely standardized across papers.
 

--- a/app/components/benchmark-blindspots.tsx
+++ b/app/components/benchmark-blindspots.tsx
@@ -1,0 +1,133 @@
+'use client'
+import React from 'react'
+
+const SCENARIOS = [
+  {
+    scenario: 'Single subject, clean reference images',
+    note: 'The standard benchmark setup',
+    dinoI: true,
+    clipT: true,
+    dreamBench: true,
+    realWorld: false,
+  },
+  {
+    scenario: 'Multi-subject scene (3+ characters)',
+    note: 'Common production use case',
+    dinoI: false,
+    clipT: false,
+    dreamBench: false,
+    realWorld: true,
+  },
+  {
+    scenario: 'Subject in complex or novel background',
+    note: '',
+    dinoI: false,
+    clipT: true,
+    dreamBench: true,
+    realWorld: true,
+  },
+  {
+    scenario: 'Consistent character across a sequence',
+    note: 'Story, comic strip, product shoot',
+    dinoI: false,
+    clipT: false,
+    dreamBench: false,
+    realWorld: true,
+  },
+  {
+    scenario: 'Zero-shot generation (no fine-tuning)',
+    note: 'Hard constraint in many production pipelines',
+    dinoI: false,
+    clipT: false,
+    dreamBench: false,
+    realWorld: true,
+  },
+  {
+    scenario: 'Generated images as reference inputs',
+    note: 'Reference is itself slightly inconsistent',
+    dinoI: false,
+    clipT: false,
+    dreamBench: false,
+    realWorld: true,
+  },
+]
+
+function Cell({
+  covered,
+  productionCritical,
+}: {
+  covered: boolean
+  productionCritical: boolean
+}) {
+  if (covered)
+    return <span className="text-green-500 dark:text-green-400">✓</span>
+  if (productionCritical)
+    return <span className="font-bold text-red-500 dark:text-red-400">✗</span>
+  return <span className="text-neutral-200 dark:text-neutral-700">○</span>
+}
+
+export function BenchmarkBlindspots() {
+  return (
+    <div className="not-prose my-8 overflow-x-auto rounded-xl border border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <div className="p-5 pb-3">
+        <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+          Benchmark Coverage vs Real Scenarios
+        </p>
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">
+          Standard benchmarks cover the easy cases. Production breaks on the
+          rest.
+        </p>
+      </div>
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="border-t border-neutral-200 dark:border-neutral-800">
+            <th className="px-5 py-2.5 text-left font-medium text-neutral-500 dark:text-neutral-400">
+              Scenario
+            </th>
+            <th className="px-3 py-2.5 text-center font-medium text-neutral-500 dark:text-neutral-400">
+              DINO-I
+            </th>
+            <th className="px-3 py-2.5 text-center font-medium text-neutral-500 dark:text-neutral-400">
+              CLIP-T
+            </th>
+            <th className="px-3 py-2.5 text-center font-medium text-neutral-500 dark:text-neutral-400">
+              DreamBench
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {SCENARIOS.map((s) => (
+            <tr
+              key={s.scenario}
+              className="border-t border-neutral-100 dark:border-neutral-800/50"
+            >
+              <td className="px-5 py-2">
+                <span className="text-neutral-700 dark:text-neutral-300">
+                  {s.scenario}
+                </span>
+                {s.note && (
+                  <span className="ml-1.5 text-neutral-400 dark:text-neutral-600">
+                    ({s.note})
+                  </span>
+                )}
+              </td>
+              <td className="px-3 py-2 text-center">
+                <Cell covered={s.dinoI} productionCritical={s.realWorld} />
+              </td>
+              <td className="px-3 py-2 text-center">
+                <Cell covered={s.clipT} productionCritical={s.realWorld} />
+              </td>
+              <td className="px-3 py-2 text-center">
+                <Cell covered={s.dreamBench} productionCritical={s.realWorld} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="border-t border-neutral-100 px-5 py-3 text-xs text-neutral-400 dark:border-neutral-800 dark:text-neutral-600">
+        ✓ evaluated &nbsp;&nbsp; ✗ missing (production-critical) &nbsp;&nbsp; ○
+        not applicable
+      </p>
+    </div>
+  )
+}

--- a/app/components/consistency-tradeoff-explorer.tsx
+++ b/app/components/consistency-tradeoff-explorer.tsx
@@ -1,0 +1,112 @@
+'use client'
+import React, { useState } from 'react'
+
+const METHODS = [
+  {
+    label: 'Full fine-tuning',
+    sub: 'DreamBooth / LoRA per subject',
+    setup: 'Minutes to hours per subject',
+    fidelity: 95,
+    composability: 15,
+    flexibility: 5,
+    desc: 'Highest DINO-I scores. Strong texture reproduction. Each new subject needs its own fine-tune. LoRA fusion breaks down at 3+ subjects.',
+  },
+  {
+    label: 'Adapter-based',
+    sub: 'IP-Adapter-Plus style',
+    setup: 'Seconds at inference time',
+    fidelity: 72,
+    composability: 45,
+    flexibility: 60,
+    desc: 'Fast and flexible. Subject stays visually consistent at a glance. Complex prompt + subject compositions break. Text alignment degrades under load.',
+  },
+  {
+    label: 'Training-free',
+    sub: 'Masked cross-image attention',
+    setup: 'Zero — reference images at inference',
+    fidelity: 58,
+    composability: 80,
+    flexibility: 95,
+    desc: 'Zero-shot, any subject count, zero setup cost. Lower DINO-I. Attention leakage appears at 3+ subjects without masking. Benchmarks penalize this; users in practice often prefer it.',
+  },
+]
+
+const METRICS = [
+  {
+    key: 'fidelity',
+    label: 'Texture fidelity (what DINO-I measures)',
+    color: 'bg-blue-500',
+  },
+  {
+    key: 'composability',
+    label: 'Multi-subject composability',
+    color: 'bg-purple-500',
+  },
+  { key: 'flexibility', label: 'Zero-shot flexibility', color: 'bg-green-500' },
+] as const
+
+export function ConsistencyTradeoffExplorer() {
+  const [sel, setSel] = useState(0)
+  const method = METHODS[sel]
+
+  return (
+    <div className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+        Consistency Method Tradeoffs
+      </p>
+      <p className="mb-4 text-xs text-neutral-500 dark:text-neutral-400">
+        Each approach optimizes for a different axis. DINO-I only measures the
+        first one.
+      </p>
+
+      <div className="mb-4 flex gap-1.5">
+        {METHODS.map((m, i) => (
+          <button
+            key={m.label}
+            onClick={() => setSel(i)}
+            className={`flex-1 rounded-lg px-2 py-2 text-xs font-medium transition-colors ${
+              sel === i
+                ? 'bg-neutral-900 text-white dark:bg-white dark:text-neutral-900'
+                : 'border border-neutral-200 text-neutral-600 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-800'
+            }`}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mb-4 rounded-lg border border-neutral-200 bg-white p-3 dark:border-neutral-700 dark:bg-neutral-950">
+        <p className="mb-0.5 text-xs font-medium text-neutral-700 dark:text-neutral-200">
+          {method.sub}
+        </p>
+        <p className="mb-2 text-xs text-neutral-400 dark:text-neutral-500">
+          Setup cost: {method.setup}
+        </p>
+        <p className="text-xs leading-relaxed text-neutral-600 dark:text-neutral-400">
+          {method.desc}
+        </p>
+      </div>
+
+      <div className="space-y-2.5">
+        {METRICS.map((m) => (
+          <div key={m.key}>
+            <div className="mb-1 flex items-center justify-between text-xs">
+              <span className="text-neutral-600 dark:text-neutral-400">
+                {m.label}
+              </span>
+              <span className="text-neutral-500 tabular-nums dark:text-neutral-500">
+                {method[m.key]}%
+              </span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-neutral-100 dark:bg-neutral-800">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${m.color}`}
+                style={{ width: `${method[m.key]}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/components/eval-coverage-matrix.tsx
+++ b/app/components/eval-coverage-matrix.tsx
@@ -1,0 +1,110 @@
+'use client'
+import React from 'react'
+
+const FAILURE_MODES = [
+  'Verbosity bias',
+  'Position bias',
+  'Self-preference bias',
+  'Factual regression',
+  'Format / schema breakage',
+  'Metric drift from user outcomes',
+]
+
+const METHODS = [
+  {
+    name: 'Deterministic checks',
+    short: 'Det.',
+    covers: [false, false, false, false, true, false],
+  },
+  {
+    name: 'Reference-based metrics',
+    short: 'Ref.',
+    covers: [false, false, false, true, true, false],
+  },
+  {
+    name: 'Same-provider judge',
+    short: 'Same',
+    covers: [false, false, false, false, false, false],
+  },
+  {
+    name: 'Cross-provider judge',
+    short: 'Cross',
+    covers: [true, false, true, false, false, false],
+  },
+  {
+    name: 'Human eval set',
+    short: 'Human',
+    covers: [true, true, true, true, true, true],
+  },
+]
+
+export function EvalCoverageMatrix() {
+  return (
+    <div className="not-prose my-8 overflow-x-auto rounded-xl border border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <div className="p-5 pb-3">
+        <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+          Eval Method Coverage
+        </p>
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">
+          Which failure modes each evaluation approach can actually catch
+        </p>
+      </div>
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="border-t border-neutral-200 dark:border-neutral-800">
+            <th className="px-5 py-2.5 text-left font-medium text-neutral-500 dark:text-neutral-400">
+              Failure mode
+            </th>
+            {METHODS.map((m) => (
+              <th
+                key={m.name}
+                className="px-3 py-2.5 text-center font-medium text-neutral-500 dark:text-neutral-400"
+                title={m.name}
+              >
+                {m.short}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {FAILURE_MODES.map((mode, i) => (
+            <tr
+              key={mode}
+              className="border-t border-neutral-100 dark:border-neutral-800/50"
+            >
+              <td className="px-5 py-2 text-neutral-700 dark:text-neutral-300">
+                {mode}
+              </td>
+              {METHODS.map((m) => (
+                <td key={m.name} className="px-3 py-2 text-center">
+                  {m.covers[i] ? (
+                    <span className="text-green-500">✓</span>
+                  ) : m.name === 'Same-provider judge' ? (
+                    <span className="text-red-400 dark:text-red-500">✗</span>
+                  ) : (
+                    <span className="text-neutral-200 dark:text-neutral-700">
+                      ○
+                    </span>
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex flex-wrap gap-4 border-t border-neutral-100 px-5 py-3 dark:border-neutral-800">
+        {METHODS.map((m) => (
+          <span
+            key={m.name}
+            className="text-xs text-neutral-400 dark:text-neutral-600"
+          >
+            <span className="font-medium text-neutral-700 dark:text-neutral-300">
+              {m.short}
+            </span>{' '}
+            = {m.name}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/components/labeled-code.tsx
+++ b/app/components/labeled-code.tsx
@@ -1,0 +1,36 @@
+export function LabeledCode({
+  type = 'note',
+  label,
+}: {
+  type?: 'good' | 'bad' | 'note'
+  label: string
+}) {
+  const config = {
+    good: {
+      className:
+        'border-green-500/40 bg-green-500/5 text-green-600 dark:text-green-400',
+      icon: '✓',
+    },
+    bad: {
+      className:
+        'border-red-500/40 bg-red-500/5 text-red-600 dark:text-red-400',
+      icon: '✗',
+    },
+    note: {
+      className:
+        'border-blue-500/40 bg-blue-500/5 text-blue-600 dark:text-blue-400',
+      icon: '→',
+    },
+  }
+
+  const { className, icon } = config[type]
+
+  return (
+    <div
+      className={`mt-6 mb-1 flex items-center gap-2 rounded border px-3 py-1.5 text-xs font-medium ${className}`}
+    >
+      <span aria-hidden="true">{icon}</span>
+      <span>{label}</span>
+    </div>
+  )
+}

--- a/app/components/mdx.tsx
+++ b/app/components/mdx.tsx
@@ -7,6 +7,12 @@ import { VibeSimulator } from 'app/components/vibe-simulator'
 import { Callout } from 'app/components/callout'
 import { StatCallout } from 'app/components/stat-callout'
 import { LabeledCode } from 'app/components/labeled-code'
+import { ToolDescriptionGrader } from 'app/components/tool-description-grader'
+import { ToolScaleSimulator } from 'app/components/tool-scale-simulator'
+import { VerbosityBiasDemo } from 'app/components/verbosity-bias-demo'
+import { EvalCoverageMatrix } from 'app/components/eval-coverage-matrix'
+import { ConsistencyTradeoffExplorer } from 'app/components/consistency-tradeoff-explorer'
+import { BenchmarkBlindspots } from 'app/components/benchmark-blindspots'
 import { PostPreviewLink } from 'app/components/post-preview-link'
 import { LinkPreview } from 'app/components/link-preview'
 import { slugify } from 'app/blog/utils.shared'
@@ -123,6 +129,12 @@ const components = {
   GistCode,
   StatCallout,
   LabeledCode,
+  ToolDescriptionGrader,
+  ToolScaleSimulator,
+  VerbosityBiasDemo,
+  EvalCoverageMatrix,
+  ConsistencyTradeoffExplorer,
+  BenchmarkBlindspots,
 }
 
 export function CustomMDX(props) {

--- a/app/components/mdx.tsx
+++ b/app/components/mdx.tsx
@@ -5,31 +5,35 @@ import React from 'react'
 import { Code, GistCode } from 'app/components/code'
 import { VibeSimulator } from 'app/components/vibe-simulator'
 import { Callout } from 'app/components/callout'
+import { StatCallout } from 'app/components/stat-callout'
+import { LabeledCode } from 'app/components/labeled-code'
 import { PostPreviewLink } from 'app/components/post-preview-link'
 import { LinkPreview } from 'app/components/link-preview'
 import { slugify } from 'app/blog/utils.shared'
 import { getBlogPosts } from 'app/blog/utils'
 
-function Table({ data }) {
-  const headers = data.headers.map((header, index) => (
-    <th key={index}>{header}</th>
-  ))
-  const rows = data.rows.map((row, index) => (
-    <tr key={index}>
-      {row.map((cell, cellIndex) => (
-        <td key={cellIndex}>{cell}</td>
-      ))}
-    </tr>
-  ))
-
-  return (
-    <table>
-      <thead>
-        <tr>{headers}</tr>
-      </thead>
-      <tbody>{rows}</tbody>
-    </table>
-  )
+function Table({ data, children }) {
+  if (data) {
+    const headers = data.headers.map((header, index) => (
+      <th key={index}>{header}</th>
+    ))
+    const rows = data.rows.map((row, index) => (
+      <tr key={index}>
+        {row.map((cell, cellIndex) => (
+          <td key={cellIndex}>{cell}</td>
+        ))}
+      </tr>
+    ))
+    return (
+      <table>
+        <thead>
+          <tr>{headers}</tr>
+        </thead>
+        <tbody>{rows}</tbody>
+      </table>
+    )
+  }
+  return <table>{children}</table>
 }
 
 function CustomLink(props) {
@@ -117,6 +121,8 @@ const components = {
   VibeSimulator,
   Callout,
   GistCode,
+  StatCallout,
+  LabeledCode,
 }
 
 export function CustomMDX(props) {

--- a/app/components/stat-callout.tsx
+++ b/app/components/stat-callout.tsx
@@ -1,0 +1,38 @@
+export function StatCallout({
+  stat,
+  label,
+  source,
+  sourceUrl,
+}: {
+  stat: string
+  label: string
+  source?: string
+  sourceUrl?: string
+}) {
+  return (
+    <div className="my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-6 text-center dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="text-5xl font-bold tracking-tight text-neutral-900 dark:text-white">
+        {stat}
+      </p>
+      <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
+        {label}
+      </p>
+      {source && (
+        <p className="mt-2 text-xs text-neutral-400 dark:text-neutral-600">
+          {sourceUrl ? (
+            <a
+              href={sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2 hover:text-neutral-600 dark:hover:text-neutral-400"
+            >
+              {source}
+            </a>
+          ) : (
+            source
+          )}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/app/components/tool-description-grader.tsx
+++ b/app/components/tool-description-grader.tsx
@@ -1,0 +1,160 @@
+'use client'
+import React, { useState, useMemo } from 'react'
+
+interface Check {
+  id: string
+  label: string
+  hint: string
+  test: (s: string) => boolean
+  weight: number
+}
+
+const CHECKS: Check[] = [
+  {
+    id: 'length',
+    label: 'Adequate length',
+    hint: 'At least 50 characters — one-liners never carry enough signal',
+    test: (s) => s.trim().length >= 50,
+    weight: 10,
+  },
+  {
+    id: 'purpose',
+    label: 'States what it does or returns',
+    hint: 'Mention what the tool retrieves, creates, or produces',
+    test: (s) =>
+      /\b(returns?|fetches?|retrieves?|gets?|creates?|searches?|finds?|lists?|generates?|sends?|calculates?|extracts?|converts?)\b/i.test(
+        s,
+      ),
+    weight: 20,
+  },
+  {
+    id: 'when',
+    label: 'Explains when to use it',
+    hint: '"Use when...", "to get...", or a concrete use-case sentence',
+    test: (s) =>
+      /\b(use when|use this when|use for|when you (need|want|have)|to (get|find|create|retrieve|fetch|search)|for (getting|finding|searching|retrieving))\b/i.test(
+        s,
+      ),
+    weight: 20,
+  },
+  {
+    id: 'antipattern',
+    label: 'Anti-patterns listed',
+    hint: '"Do NOT use for X — use Y() instead"',
+    test: (s) =>
+      /\b(do not use|don'?t use|not for|avoid using|instead use|use .+ instead)\b/i.test(
+        s,
+      ),
+    weight: 30,
+  },
+  {
+    id: 'params',
+    label: 'Required inputs mentioned',
+    hint: 'Reference required parameters or context',
+    test: (s) =>
+      /\b(requires?|needs?|expects?|must (have|provide|pass|supply)|with a valid|provide (a|an|the)|pass (a|an|the))\b/i.test(
+        s,
+      ),
+    weight: 20,
+  },
+]
+
+function ScoreTag({ score }: { score: number }) {
+  if (score >= 80)
+    return (
+      <span className="font-medium text-green-600 dark:text-green-400">
+        Good
+      </span>
+    )
+  if (score >= 50)
+    return (
+      <span className="font-medium text-yellow-600 dark:text-yellow-400">
+        Needs work
+      </span>
+    )
+  return (
+    <span className="font-medium text-red-600 dark:text-red-400">
+      Likely causing errors
+    </span>
+  )
+}
+
+export function ToolDescriptionGrader() {
+  const [input, setInput] = useState('')
+
+  const results = useMemo(() => {
+    const trimmed = input.trim()
+    if (!trimmed) return null
+    const checks = CHECKS.map((c) => ({ ...c, passed: c.test(trimmed) }))
+    const score = checks.reduce((sum, c) => sum + (c.passed ? c.weight : 0), 0)
+    return { checks, score }
+  }, [input])
+
+  const barColor = results
+    ? results.score >= 80
+      ? 'bg-green-500'
+      : results.score >= 50
+        ? 'bg-yellow-500'
+        : 'bg-red-500'
+    : 'bg-neutral-300 dark:bg-neutral-600'
+
+  return (
+    <div className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+        Tool Description Grader
+      </p>
+      <p className="mb-4 text-xs text-neutral-500 dark:text-neutral-400">
+        Paste a tool description to see what signal the model actually reads
+      </p>
+      <textarea
+        className="w-full rounded-lg border border-neutral-200 bg-white p-3 font-mono text-xs text-neutral-900 placeholder-neutral-400 focus:border-neutral-400 focus:outline-none dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder-neutral-600"
+        rows={3}
+        placeholder="Gets data for a user."
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+      />
+      {results && (
+        <div className="mt-3 space-y-3">
+          <div className="flex items-center gap-3">
+            <div className="h-2 flex-1 overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-700">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${barColor}`}
+                style={{ width: `${results.score}%` }}
+              />
+            </div>
+            <div className="w-36 text-right text-xs text-neutral-600 dark:text-neutral-400">
+              {results.score}/100 &mdash; <ScoreTag score={results.score} />
+            </div>
+          </div>
+          <ul className="space-y-1.5">
+            {results.checks.map((c) => (
+              <li key={c.id} className="flex items-start gap-2 text-xs">
+                <span
+                  className={`mt-px shrink-0 font-mono ${c.passed ? 'text-green-500' : 'text-neutral-300 dark:text-neutral-600'}`}
+                >
+                  {c.passed ? '✓' : '○'}
+                </span>
+                <span>
+                  <span
+                    className={
+                      c.passed
+                        ? 'text-neutral-700 dark:text-neutral-300'
+                        : 'text-neutral-400 dark:text-neutral-600'
+                    }
+                  >
+                    {c.label}
+                  </span>
+                  {!c.passed && (
+                    <span className="ml-1 text-neutral-400 dark:text-neutral-500">
+                      &mdash; {c.hint}
+                    </span>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/components/tool-scale-simulator.tsx
+++ b/app/components/tool-scale-simulator.tsx
@@ -1,0 +1,130 @@
+'use client'
+import React, { useState } from 'react'
+
+const ZONES = [
+  {
+    max: 5,
+    label: 'Safe zone',
+    color: 'green' as const,
+    desc: 'Reliable selection. Model can distinguish all tools. Focus on description quality, not architecture.',
+  },
+  {
+    max: 12,
+    label: 'Caution',
+    color: 'yellow' as const,
+    desc: 'Occasional wrong selection for semantically similar tools. Audit descriptions and add anti-patterns.',
+  },
+  {
+    max: 20,
+    label: 'Danger zone',
+    color: 'orange' as const,
+    desc: 'Consistent confusion between overlapping tools. Phantom function calls appear. A retrieval layer is overdue.',
+  },
+  {
+    max: Infinity,
+    label: 'Overloaded',
+    color: 'red' as const,
+    desc: 'Flat-list injection is unsafe at this scale. registry.query(context, top_k=8) is required.',
+  },
+]
+
+type Color = (typeof ZONES)[number]['color']
+
+const colorMap: Record<
+  Color,
+  { bar: string; text: string; bg: string; border: string }
+> = {
+  green: {
+    bar: 'bg-green-500',
+    text: 'text-green-700 dark:text-green-400',
+    bg: 'bg-green-50 dark:bg-green-950/40',
+    border: 'border-green-200 dark:border-green-900',
+  },
+  yellow: {
+    bar: 'bg-yellow-500',
+    text: 'text-yellow-700 dark:text-yellow-400',
+    bg: 'bg-yellow-50 dark:bg-yellow-950/40',
+    border: 'border-yellow-200 dark:border-yellow-900',
+  },
+  orange: {
+    bar: 'bg-orange-500',
+    text: 'text-orange-700 dark:text-orange-400',
+    bg: 'bg-orange-50 dark:bg-orange-950/40',
+    border: 'border-orange-200 dark:border-orange-900',
+  },
+  red: {
+    bar: 'bg-red-500',
+    text: 'text-red-700 dark:text-red-400',
+    bg: 'bg-red-50 dark:bg-red-950/40',
+    border: 'border-red-200 dark:border-red-900',
+  },
+}
+
+function getAccuracy(n: number): number {
+  if (n <= 5) return 97
+  if (n <= 12) return Math.round(97 - (n - 5) * 4.5)
+  if (n <= 20) return Math.round(65 - (n - 12) * 2.5)
+  return Math.max(18, Math.round(45 - (n - 20) * 1.3))
+}
+
+export function ToolScaleSimulator() {
+  const [count, setCount] = useState(8)
+
+  const zone = ZONES.find((z) => count <= z.max)!
+  const accuracy = getAccuracy(count)
+  const c = colorMap[zone.color]
+
+  return (
+    <div className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+        Tool Count Simulator
+      </p>
+      <p className="mb-4 text-xs text-neutral-500 dark:text-neutral-400">
+        Drag to change registry size and see estimated selection accuracy
+      </p>
+
+      <div className="mb-4 flex items-center gap-4">
+        <input
+          type="range"
+          min={1}
+          max={40}
+          value={count}
+          onChange={(e) => setCount(Number(e.target.value))}
+          className="flex-1 accent-neutral-700 dark:accent-neutral-300"
+        />
+        <span className="w-16 text-right text-2xl font-bold text-neutral-900 tabular-nums dark:text-white">
+          {count}
+        </span>
+      </div>
+
+      <div className="mb-3 grid grid-cols-2 gap-2">
+        <div className="rounded-lg border border-neutral-200 bg-white p-3 dark:border-neutral-700 dark:bg-neutral-950">
+          <p className="mb-1 text-xs text-neutral-500 dark:text-neutral-400">
+            Est. selection accuracy
+          </p>
+          <p className="text-xl font-bold text-neutral-900 dark:text-white">
+            {accuracy}%
+          </p>
+          <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-neutral-100 dark:bg-neutral-800">
+            <div
+              className="h-full rounded-full bg-blue-500 transition-all duration-500"
+              style={{ width: `${accuracy}%` }}
+            />
+          </div>
+        </div>
+        <div className={`rounded-lg border p-3 ${c.bg} ${c.border}`}>
+          <p className="mb-1 text-xs text-neutral-500 dark:text-neutral-400">
+            Status
+          </p>
+          <p className={`text-xl font-bold ${c.text}`}>{zone.label}</p>
+        </div>
+      </div>
+
+      <div
+        className={`rounded-lg border p-3 text-xs ${c.bg} ${c.border} ${c.text}`}
+      >
+        {zone.desc}
+      </div>
+    </div>
+  )
+}

--- a/app/components/verbosity-bias-demo.tsx
+++ b/app/components/verbosity-bias-demo.tsx
@@ -1,0 +1,115 @@
+'use client'
+import React, { useState } from 'react'
+
+const SHORT = {
+  label: 'Concise answer',
+  words: 6,
+  text: 'Paris is the capital of France.',
+  score: 5.1,
+}
+
+const VERBOSE = {
+  label: 'Padded answer',
+  words: 63,
+  text: "That's a great question! Paris, which has been the capital of France since the late 10th century, is indeed the capital of France. It serves as the country's political, economic, and cultural center. The city, situated along the Seine river, has a rich history spanning over 2,000 years and is home to iconic landmarks. To summarize: Paris is the capital of France.",
+  score: 8.2,
+}
+
+type State = 'idle' | 'judging' | 'done'
+
+export function VerbosityBiasDemo() {
+  const [flipped, setFlipped] = useState(false)
+  const [state, setState] = useState<State>('idle')
+
+  const a = flipped ? VERBOSE : SHORT
+  const b = flipped ? SHORT : VERBOSE
+
+  function runJudge() {
+    setState('judging')
+    setTimeout(() => setState('done'), 1400)
+  }
+
+  function swap() {
+    setFlipped((f) => !f)
+    setState('idle')
+  }
+
+  return (
+    <div className="not-prose my-8 rounded-xl border border-neutral-200 bg-neutral-50 p-5 dark:border-neutral-800 dark:bg-neutral-900/40">
+      <p className="mb-0.5 text-sm font-semibold text-neutral-900 dark:text-white">
+        Verbosity + Position Bias Demo
+      </p>
+      <p className="mb-1 text-xs text-neutral-500 dark:text-neutral-400">
+        Both responses are factually correct. Run the judge to see which wins.
+      </p>
+      <p className="mb-4 text-xs text-neutral-400 italic dark:text-neutral-600">
+        Q: What is the capital of France?
+      </p>
+
+      <div className="mb-4 grid grid-cols-2 gap-3">
+        {[a, b].map((ans, i) => (
+          <div
+            key={i}
+            className="flex flex-col rounded-lg border border-neutral-200 bg-white p-3 dark:border-neutral-700 dark:bg-neutral-950"
+          >
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-xs font-medium text-neutral-500">
+                Response {i === 0 ? 'A' : 'B'}
+              </span>
+              <span className="text-xs text-neutral-400">{ans.words}w</span>
+            </div>
+            <p className="flex-1 text-xs leading-relaxed text-neutral-700 dark:text-neutral-300">
+              {ans.text}
+            </p>
+            {state === 'done' && (
+              <div className="mt-3 border-t border-neutral-100 pt-3 dark:border-neutral-800">
+                <div className="mb-1 flex items-center justify-between">
+                  <span className="text-xs text-neutral-400">Judge score</span>
+                  <span
+                    className={`text-sm font-bold tabular-nums ${ans.score > 7 ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'}`}
+                  >
+                    {ans.score}/10
+                  </span>
+                </div>
+                <div className="h-1.5 overflow-hidden rounded-full bg-neutral-100 dark:bg-neutral-800">
+                  <div
+                    className={`h-full rounded-full transition-all duration-700 ${ans.score > 7 ? 'bg-green-500' : 'bg-red-400'}`}
+                    style={{ width: `${ans.score * 10}%` }}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          onClick={runJudge}
+          disabled={state === 'judging'}
+          className="flex-1 rounded-lg bg-neutral-900 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-neutral-700 disabled:opacity-50 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-200"
+        >
+          {state === 'judging'
+            ? 'Judging…'
+            : state === 'done'
+              ? 'Re-run judge'
+              : 'Run gpt-4o judge'}
+        </button>
+        <button
+          onClick={swap}
+          className="rounded-lg border border-neutral-200 px-3 py-2 text-xs font-medium text-neutral-600 transition-colors hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-400 dark:hover:bg-neutral-800"
+        >
+          Swap order
+        </button>
+      </div>
+
+      {state === 'done' && (
+        <p className="mt-3 text-xs text-neutral-500 dark:text-neutral-400">
+          {flipped
+            ? 'Verbose answer is now in position A and still wins. Longer always beats shorter. Earlier always beats later. Both biases confirmed.'
+            : 'Verbose answer wins despite identical facts. Now swap the order — position B next.'}
+        </p>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- New blog post: *The Benchmark That Rewards Memorization Over Consistency*
- Argues DINO-I rewards texture memorization, not subject consistency — explaining why training-free methods appear to lose benchmarks while solving the harder practical problem
- Grounded in StorySync (arXiv:2508.03735) research: masked cross-image attention, attention leakage, Regional Feature Harmonization
- Covers FLUX architecture improvements, FreeCus/Storybooth comparisons, and the Pareto front between DINO-I and CLIP-T
- Calls for better benchmarks that reflect multi-subject, multi-scene use cases

## Test plan

- [ ] Verify post renders correctly at `/blog/benchmark-memorization`
- [ ] Check Callout component renders (not HTML-escaped)
- [ ] Verify all arXiv and external links resolve
- [ ] Confirm frontmatter tags display correctly
- [ ] Review on mobile