### PR TITLE
fix: pin pnpm version, restore Vercel compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - uses: actions/setup-node@v4
         with:
@@ -34,8 +32,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "packageManager": "pnpm@10.18.0",
   "scripts": {
     "dev": "[ -d node_modules ] || pnpm install && tinacms dev -c \"next dev\"",
     "build": "pnpm embed && next build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - '.'
+
 onlyBuiltDependencies:
   - sharp

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,2 @@
-allowBuilds:
-  better-sqlite3: false
-  core-js: false
-  esbuild: false
-  protobufjs: false
-  sharp: true
-  unrs-resolver: false
+onlyBuiltDependencies:
+  - sharp


### PR DESCRIPTION
## Summary
Follow-up to #30. That PR had auto-merge enabled and merged as soon as CI (which only ran pnpm@11-compatible config) went green — but its last commit broke the **production** Vercel deployment, which resolves this project to pnpm@9.x. `main` is currently failing to deploy.

- Pin `"packageManager": "pnpm@10.18.0"` in package.json and drop the floating `version: latest` in `ci.yml`, so GH Actions/local dev/Vercel aren't drifting across 3 different pnpm majors with incompatible config schemas (10 → 11 removed `onlyBuiltDependencies` for `allowBuilds`; that's what #30 shipped and broke Vercel).
- Revert `pnpm-workspace.yaml` to the pnpm-10-compatible `onlyBuiltDependencies` syntax.
- Add the `packages` field pnpm@9 requires on any `pnpm-workspace.yaml` (Vercel still resolves to pnpm@9.x for this project regardless of the packageManager pin — enabling Corepack there requires a project settings change, out of scope here).

## Test plan
- [x] `pnpm install --frozen-lockfile` verified clean under pnpm@9, pnpm@10.18.0 (pinned), and pnpm@11
- [x] `next build` verified under pnpm@9 (matches what Vercel actually runs)
- [x] `pnpm test` — 53/53 passing
- [ ] Merge promptly — main is currently broken on Vercel until this lands